### PR TITLE
Fix mapping lookup for extra state values

### DIFF
--- a/cli/src/main/java/com/hivemc/chunker/mapping/MappingsFile.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/MappingsFile.java
@@ -3,6 +3,7 @@ package com.hivemc.chunker.mapping;
 import com.google.gson.*;
 import com.hivemc.chunker.mapping.identifier.Identifier;
 import com.hivemc.chunker.mapping.identifier.states.StateValue;
+import com.hivemc.chunker.mapping.identifier.states.StateValueString;
 import com.hivemc.chunker.mapping.mappings.IdentifierMapping;
 import com.hivemc.chunker.mapping.mappings.IdentifierMappings;
 import com.hivemc.chunker.mapping.mappings.StateMappings;
@@ -223,6 +224,27 @@ public class MappingsFile {
 
             // Apply the identifier mapping
             identifierMapping = entry.getValue().get(inputValues);
+            if (identifierMapping == null) {
+                // Fallback to case-insensitive matching for string values
+                outer:
+                for (Map.Entry<List<StateValue<?>>, IdentifierMapping> valEntry : entry.getValue().entrySet()) {
+                    List<StateValue<?>> keyValues = valEntry.getKey();
+                    if (keyValues.size() != inputValues.size()) continue;
+                    for (int i = 0; i < keyValues.size(); i++) {
+                        StateValue<?> expected = keyValues.get(i);
+                        StateValue<?> actual = inputValues.get(i);
+                        if (expected instanceof StateValueString e && actual instanceof StateValueString a) {
+                            if (!e.getValue().equalsIgnoreCase(a.getValue())) {
+                                continue outer;
+                            }
+                        } else if (!Objects.equals(expected, actual)) {
+                            continue outer;
+                        }
+                    }
+                    identifierMapping = valEntry.getValue();
+                    break;
+                }
+            }
             if (identifierMapping != null) {
                 break; // Found value
             }

--- a/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
@@ -3,6 +3,7 @@ package com.hivemc.chunker.mapping;
 import com.hivemc.chunker.mapping.identifier.Identifier;
 import com.hivemc.chunker.mapping.identifier.states.StateValueInt;
 import com.hivemc.chunker.mapping.identifier.states.StateValueString;
+import com.hivemc.chunker.mapping.identifier.states.StateValueBoolean;
 import com.hivemc.chunker.mapping.parser.SimpleMappingsParser;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +52,26 @@ public class SimpleMappingsParserTest {
         MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
         Identifier input = new Identifier("minecraft:stairs", Map.of("facing", new StateValueString("EAST")));
         Identifier expected = new Identifier("112", Map.of("facing", new StateValueString("EAST"), "data", new StateValueInt(3)));
+        assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
+    }
+
+    @Test
+    public void testExtraStates() throws IOException {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(), "minecraft:stripped_spruce_log[axis=Y] -> 3006:0\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:stripped_spruce_log", Map.of(
+                "axis", new StateValueString("Y"),
+                "waterlogged", StateValueBoolean.FALSE
+        ));
+        Identifier expected = new Identifier("3006", Map.of(
+                "axis", new StateValueString("Y"),
+                "waterlogged", StateValueBoolean.FALSE,
+                "data", new StateValueInt(0)
+        ));
+
         assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
     }
 }


### PR DESCRIPTION
## Summary
- support case-insensitive matching of state values in `MappingsFile`
- add regression test ensuring mappings still work when additional states are present

## Testing
- `./gradlew --no-daemon test --tests "com.hivemc.chunker.mapping.SimpleMappingsParserTest"`

------
https://chatgpt.com/codex/tasks/task_e_6878542876948323a12a733171c40090