### PR TITLE
Improve simple mapping parsing

### DIFF
--- a/cli/src/main/java/com/hivemc/chunker/mapping/MappingsFile.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/MappingsFile.java
@@ -4,6 +4,8 @@ import com.google.gson.*;
 import com.hivemc.chunker.mapping.identifier.Identifier;
 import com.hivemc.chunker.mapping.identifier.states.StateValue;
 import com.hivemc.chunker.mapping.identifier.states.StateValueString;
+import com.hivemc.chunker.mapping.identifier.states.StateValueBoolean;
+import com.hivemc.chunker.mapping.identifier.states.StateValueInt;
 import com.hivemc.chunker.mapping.mappings.IdentifierMapping;
 import com.hivemc.chunker.mapping.mappings.IdentifierMappings;
 import com.hivemc.chunker.mapping.mappings.StateMappings;
@@ -246,8 +248,34 @@ public class MappingsFile {
                     for (int i = 0; i < keyValues.size(); i++) {
                         StateValue<?> expected = keyValues.get(i);
                         StateValue<?> actual = inputValues.get(i);
+
+                        // Allow cross-type comparisons for common state formats
                         if (expected instanceof StateValueString e && actual instanceof StateValueString a) {
                             if (!e.getValue().equalsIgnoreCase(a.getValue())) {
+                                continue outer;
+                            }
+                        } else if (expected instanceof StateValueBoolean eb && actual instanceof StateValueString as) {
+                            if (eb.getValue() != Boolean.parseBoolean(as.getValue())) {
+                                continue outer;
+                            }
+                        } else if (expected instanceof StateValueString es && actual instanceof StateValueBoolean ab) {
+                            if (ab.getValue() != Boolean.parseBoolean(es.getValue())) {
+                                continue outer;
+                            }
+                        } else if (expected instanceof StateValueInt ei && actual instanceof StateValueString ais) {
+                            try {
+                                if (ei.getValue() != Integer.parseInt(ais.getValue())) {
+                                    continue outer;
+                                }
+                            } catch (NumberFormatException ex) {
+                                continue outer;
+                            }
+                        } else if (expected instanceof StateValueString eis && actual instanceof StateValueInt ai) {
+                            try {
+                                if (ai.getValue() != Integer.parseInt(eis.getValue())) {
+                                    continue outer;
+                                }
+                            } catch (NumberFormatException ex) {
                                 continue outer;
                             }
                         } else if (!Objects.equals(expected, actual)) {

--- a/cli/src/main/java/com/hivemc/chunker/mapping/MappingsFile.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/MappingsFile.java
@@ -3,6 +3,7 @@ package com.hivemc.chunker.mapping;
 import com.google.gson.*;
 import com.hivemc.chunker.mapping.identifier.Identifier;
 import com.hivemc.chunker.mapping.identifier.states.StateValue;
+import com.hivemc.chunker.mapping.identifier.states.StateValueString;
 import com.hivemc.chunker.mapping.mappings.IdentifierMapping;
 import com.hivemc.chunker.mapping.mappings.IdentifierMappings;
 import com.hivemc.chunker.mapping.mappings.StateMappings;
@@ -223,6 +224,27 @@ public class MappingsFile {
 
             // Apply the identifier mapping
             identifierMapping = entry.getValue().get(inputValues);
+            if (identifierMapping == null) {
+                // Fallback to case-insensitive matching for string values
+                outer:
+                for (Map.Entry<List<StateValue<?>>, IdentifierMapping> valEntry : entry.getValue().entrySet()) {
+                    List<StateValue<?>> keyValues = valEntry.getKey();
+                    if (keyValues.size() != inputValues.size()) continue;
+                    for (int i = 0; i < keyValues.size(); i++) {
+                        StateValue<?> expected = keyValues.get(i);
+                        StateValue<?> actual = inputValues.get(i);
+                        if (expected instanceof StateValueString e && actual instanceof StateValueString a) {
+                            if (!e.getValue().equalsIgnoreCase(a.getValue())) {
+                                continue outer;
+                            }
+                        } else if (!Objects.equals(expected, actual)) {
+                            continue outer;
+                        }
+                    }
+                    identifierMapping = valEntry.getValue();
+                    break;
+                }
+            }
             if (identifierMapping != null) {
                 break; // Found value
             }

--- a/cli/src/main/java/com/hivemc/chunker/mapping/parser/SimpleMappingsParser.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/parser/SimpleMappingsParser.java
@@ -97,7 +97,7 @@ public final class SimpleMappingsParser {
                     if (kv.length != 2) {
                         throw new IOException("Invalid state entry: " + pair);
                     }
-                    String key = kv[0].trim();
+                    String key = kv[0].trim().toLowerCase();
                     String value = kv[1].trim();
                     statesObj.add(key, parseValue(value));
                 }

--- a/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
@@ -128,4 +128,25 @@ public class SimpleMappingsParserTest {
 
         assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
     }
+
+    @Test
+    public void testBooleanStringEquivalence() throws IOException {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:acacia_trapdoor[open=false] -> 3006:0\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:acacia_trapdoor", Map.of(
+                "open", new StateValueString("false"),
+                "powered", StateValueBoolean.FALSE
+        ));
+        Identifier expected = new Identifier("3006", Map.of(
+                "open", new StateValueString("false"),
+                "powered", StateValueBoolean.FALSE,
+                "data", new StateValueInt(0)
+        ));
+
+        assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
+    }
 }

--- a/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
@@ -101,4 +101,31 @@ public class SimpleMappingsParserTest {
 
         assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
     }
+
+    @Test
+    public void testCaseInsensitiveStateKeys() throws IOException {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:acacia_trapdoor[facing=north,half=top,open=false] -> 3006:2\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:acacia_trapdoor", Map.of(
+                "FACING", new StateValueString("north"),
+                "Half", new StateValueString("top"),
+                "Open", StateValueBoolean.FALSE,
+                "powered", StateValueBoolean.FALSE,
+                "waterlogged", StateValueBoolean.FALSE
+        ));
+        Identifier expected = new Identifier("3006", Map.of(
+                "FACING", new StateValueString("north"),
+                "Half", new StateValueString("top"),
+                "Open", StateValueBoolean.FALSE,
+                "powered", StateValueBoolean.FALSE,
+                "waterlogged", StateValueBoolean.FALSE,
+                "data", new StateValueInt(2)
+        ));
+
+        assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
+    }
 }

--- a/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
@@ -3,6 +3,7 @@ package com.hivemc.chunker.mapping;
 import com.hivemc.chunker.mapping.identifier.Identifier;
 import com.hivemc.chunker.mapping.identifier.states.StateValueInt;
 import com.hivemc.chunker.mapping.identifier.states.StateValueString;
+import com.hivemc.chunker.mapping.identifier.states.StateValueBoolean;
 import com.hivemc.chunker.mapping.parser.SimpleMappingsParser;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +52,53 @@ public class SimpleMappingsParserTest {
         MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
         Identifier input = new Identifier("minecraft:stairs", Map.of("facing", new StateValueString("EAST")));
         Identifier expected = new Identifier("112", Map.of("facing", new StateValueString("EAST"), "data", new StateValueInt(3)));
+        assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
+    }
+
+    @Test
+    public void testExtraStates() throws IOException {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(), "minecraft:stripped_spruce_log[axis=Y] -> 3006:0\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:stripped_spruce_log", Map.of(
+                "axis", new StateValueString("Y"),
+                "waterlogged", StateValueBoolean.FALSE
+        ));
+        Identifier expected = new Identifier("3006", Map.of(
+                "axis", new StateValueString("Y"),
+                "waterlogged", StateValueBoolean.FALSE,
+                "data", new StateValueInt(0)
+        ));
+
+        assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
+    }
+
+    @Test
+    public void testTrapdoorWithPoweredState() throws IOException {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:acacia_trapdoor[facing=NORTH,half=TOP,open=FALSE] -> 3006:2\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:acacia_trapdoor", Map.of(
+                "facing", new StateValueString("NORTH"),
+                "half", new StateValueString("TOP"),
+                "open", StateValueBoolean.FALSE,
+                "powered", StateValueBoolean.FALSE,
+                "waterlogged", StateValueBoolean.FALSE
+        ));
+        Identifier expected = new Identifier("3006", Map.of(
+                "facing", new StateValueString("NORTH"),
+                "half", new StateValueString("TOP"),
+                "open", StateValueBoolean.FALSE,
+                "powered", StateValueBoolean.FALSE,
+                "waterlogged", StateValueBoolean.FALSE,
+                "data", new StateValueInt(2)
+        ));
+
         assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
     }
 }


### PR DESCRIPTION
## Summary
- normalize state keys to lowercase when parsing simple mappings
- add regression test showing trapdoors map correctly with extra states

## Testing
- `./gradlew --no-daemon test`

------
https://chatgpt.com/codex/tasks/task_e_6878542876948323a12a733171c40090