### PR TITLE
Add Java 1.7.10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Supported Formats:
     - 1.20.0 - 1.20.80
     - 1.21.0 - 1.21.90
 - Java
+    - 1.7.10
     - 1.8.8
     - 1.9.0 - 1.9.3
     - 1.10.0 - 1.10.2
@@ -70,7 +71,7 @@ The following parameters are required:
 - `-i` / `--inputDirectory` - the path relative to the application which should be used as the input directory.
 - `-o` / `--outputDirectory` - the path relative to the application which should be used as the output directory.
 - `-f` / `--outputFormat` - the output format to convert the world to in the form `EDITION_X_Y_Z`,
-  e.g. `JAVA_1_20_5`, `JAVA_1_20`, `BEDROCK_1_19_30`.
+  e.g. `JAVA_1_20_5`, `JAVA_1_7_10`, `BEDROCK_1_19_30`.
 
 Additionally, the following parameters are supported:
 

--- a/cli/data/README.md
+++ b/cli/data/README.md
@@ -1,7 +1,6 @@
 # Java Data Generation
 
-This Python script aims to extract useful information for Chunker out of several Minecraft versions using the
-Minecraft Java Server software.
+This Python script aims to extract useful information for Chunker out of several Minecraft versions using the Minecraft Java Server software.
 
 By using this script you agree to any EULAs present when downloading copies of the Minecraft Java server software.
 
@@ -14,5 +13,4 @@ To use this project you will need the following:
 
 ### Automatically running the software against various versions using Python
 
-Run `python3 generate_java.py` and the script will automatically download and run the included util and all possible java
-server versions from latest to 1.8.8. This will then output the data into the same directory.
+Run `python3 generate_java.py` and the script will automatically download and run the included util and all possible java server versions from latest to 1.7.10. This will then output the data into the same directory.

--- a/cli/data/generate_java.py
+++ b/cli/data/generate_java.py
@@ -138,7 +138,7 @@ def download_version(version_id, version_url):
                     json.dump(obj, file, indent=2)
 
 
-# Fetch the version list and download the versions down to 1.8.7 marked as release
+# Fetch the version list and download the versions down to 1.7.9 marked as release
 response = requests.get("https://launchermeta.mojang.com/mc/game/version_manifest.json")
 version_manifest = response.json()
 
@@ -148,6 +148,6 @@ for version in version_manifest["versions"]:
         version["id"] = "1.21.6"
     if version["type"] == "snapshot":
         continue
-    if version["id"] == "1.8.7":
-        break  # Don't download versions below 1.8.8
+    if version["id"] == "1.7.9":
+        break  # Don't download versions below 1.7.10
     download_version(version["id"], version["url"])

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/JavaDataVersion.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/JavaDataVersion.java
@@ -16,6 +16,9 @@ public class JavaDataVersion implements Comparable<JavaDataVersion> {
     private static final TreeMap<Integer, JavaDataVersion> DATA_VERSION_LOOKUP = new TreeMap<>();
     private static final TreeMap<Version, JavaDataVersion> VERSION_LOOKUP = new TreeMap<>();
 
+    // 1.7 (no data versions)
+    public static final JavaDataVersion V1_7_10 = register(-1, new Version(1, 7, 10));
+
     // 1.8 (no data versions)
     public static final JavaDataVersion V1_8_8 = register(0, new Version(1, 8, 8));
 
@@ -199,7 +202,7 @@ public class JavaDataVersion implements Comparable<JavaDataVersion> {
             if (versionTag == null) {
                 // If this is null, it's likely an older version or not a valid NBT dat
                 if (level.getInt("version", -1) != LAST_ANVIL_FILE_VERSION) {
-                    // Currently only the last anvil file format is handled (as 1.8.8)
+                    // Currently only the last anvil file format is handled (1.7.10+)
                     return Optional.empty();
                 }
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/JavaEncoders.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/JavaEncoders.java
@@ -23,6 +23,11 @@ public class JavaEncoders {
     static {
         // This is a list of encoders (not required for every version) but versions where format changes
         register(
+                JavaDataVersion.V1_7_10,
+                JavaLevelReader::new,
+                JavaLevelWriter::new
+        );
+        register(
                 JavaDataVersion.V1_8_8,
                 JavaLevelReader::new,
                 JavaLevelWriter::new

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIDResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIDResolver.java
@@ -183,39 +183,45 @@ public class JavaLegacyBlockIDResolver implements Resolver<Integer, String> {
         mapping.put("minecraft:log2", 162);
         mapping.put("minecraft:acacia_stairs", 163);
         mapping.put("minecraft:dark_oak_stairs", 164);
-        mapping.put("minecraft:slime", 165);
-        mapping.put("minecraft:barrier", 166);
-        mapping.put("minecraft:iron_trapdoor", 167);
-        mapping.put("minecraft:prismarine", 168);
-        mapping.put("minecraft:sea_lantern", 169);
+
+        // 1.7+
         mapping.put("minecraft:hay_block", 170);
         mapping.put("minecraft:carpet", 171);
         mapping.put("minecraft:hardened_clay", 172);
         mapping.put("minecraft:coal_block", 173);
         mapping.put("minecraft:packed_ice", 174);
         mapping.put("minecraft:double_plant", 175);
-        mapping.put("minecraft:standing_banner", 176);
-        mapping.put("minecraft:wall_banner", 177);
-        mapping.put("minecraft:daylight_detector_inverted", 178);
-        mapping.put("minecraft:red_sandstone", 179);
-        mapping.put("minecraft:red_sandstone_stairs", 180);
-        mapping.put("minecraft:double_stone_slab2", 181);
-        mapping.put("minecraft:stone_slab2", 182);
-        mapping.put("minecraft:spruce_fence_gate", 183);
-        mapping.put("minecraft:birch_fence_gate", 184);
-        mapping.put("minecraft:jungle_fence_gate", 185);
-        mapping.put("minecraft:dark_oak_fence_gate", 186);
-        mapping.put("minecraft:acacia_fence_gate", 187);
-        mapping.put("minecraft:spruce_fence", 188);
-        mapping.put("minecraft:birch_fence", 189);
-        mapping.put("minecraft:jungle_fence", 190);
-        mapping.put("minecraft:dark_oak_fence", 191);
-        mapping.put("minecraft:acacia_fence", 192);
-        mapping.put("minecraft:spruce_door", 193);
-        mapping.put("minecraft:birch_door", 194);
-        mapping.put("minecraft:jungle_door", 195);
-        mapping.put("minecraft:acacia_door", 196);
-        mapping.put("minecraft:dark_oak_door", 197);
+
+        // 1.8.0
+        if (version.isGreaterThanOrEqual(1, 8, 0)) {
+            mapping.put("minecraft:slime", 165);
+            mapping.put("minecraft:barrier", 166);
+            mapping.put("minecraft:iron_trapdoor", 167);
+            mapping.put("minecraft:prismarine", 168);
+            mapping.put("minecraft:sea_lantern", 169);
+            mapping.put("minecraft:standing_banner", 176);
+            mapping.put("minecraft:wall_banner", 177);
+            mapping.put("minecraft:daylight_detector_inverted", 178);
+            mapping.put("minecraft:red_sandstone", 179);
+            mapping.put("minecraft:red_sandstone_stairs", 180);
+            mapping.put("minecraft:double_stone_slab2", 181);
+            mapping.put("minecraft:stone_slab2", 182);
+            mapping.put("minecraft:spruce_fence_gate", 183);
+            mapping.put("minecraft:birch_fence_gate", 184);
+            mapping.put("minecraft:jungle_fence_gate", 185);
+            mapping.put("minecraft:dark_oak_fence_gate", 186);
+            mapping.put("minecraft:acacia_fence_gate", 187);
+            mapping.put("minecraft:spruce_fence", 188);
+            mapping.put("minecraft:birch_fence", 189);
+            mapping.put("minecraft:jungle_fence", 190);
+            mapping.put("minecraft:dark_oak_fence", 191);
+            mapping.put("minecraft:acacia_fence", 192);
+            mapping.put("minecraft:spruce_door", 193);
+            mapping.put("minecraft:birch_door", 194);
+            mapping.put("minecraft:jungle_door", 195);
+            mapping.put("minecraft:acacia_door", 196);
+            mapping.put("minecraft:dark_oak_door", 197);
+        }
 
         // 1.9
         if (version.isGreaterThanOrEqual(1, 9, 0)) {


### PR DESCRIPTION
## Summary
- support generating data down to 1.7.10
- mention 1.7.10 in docs
- register V1_7_10 version and encoder
- gate blocks introduced in 1.8 from older versions
- clarify comment about anvil format
- clean up data generation README
- show 1.7.10 in CLI format example

## Testing
- `./gradlew :cli:test --tests com.hivemc.chunker.conversion.java.JavaEncodersTests --no-daemon --console=plain`
- `./gradlew test --no-daemon --console=plain` *(failed: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_687a83a834688323a5d1550222e04d3e