### PR TITLE
Fix legacy handlers for 1.7.10

### DIFF
--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyBannerBlockEntityHandler.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyBannerBlockEntityHandler.java
@@ -97,7 +97,11 @@ public class JavaLegacyBannerBlockEntityHandler extends BlockEntityHandler<JavaR
         output.put("Patterns", patternTags);
 
         if (value.getCustomName() != null) {
-            output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            if (resolvers.dataVersion().getVersion().isLessThan(1, 8, 0)) {
+                output.put("CustomName", JsonTextUtil.toLegacy(value.getCustomName(), false));
+            } else {
+                output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            }
         }
     }
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyBeaconBlockEntityHandler.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyBeaconBlockEntityHandler.java
@@ -37,7 +37,11 @@ public class JavaLegacyBeaconBlockEntityHandler extends BlockEntityHandler<JavaR
         }
 
         if (value.getCustomName() != null) {
-            output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            if (resolvers.dataVersion().getVersion().isLessThan(1, 8, 0)) {
+                output.put("CustomName", JsonTextUtil.toLegacy(value.getCustomName(), false));
+            } else {
+                output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            }
         }
     }
 }

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyCommandBlockBlockEntityHandler.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyCommandBlockBlockEntityHandler.java
@@ -33,7 +33,11 @@ public class JavaLegacyCommandBlockBlockEntityHandler extends BlockEntityHandler
         output.put("TrackOutput", value.isTrackOutput() ? (byte) 1 : (byte) 0);
 
         if (value.getCustomName() != null) {
-            output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            if (resolvers.dataVersion().getVersion().isLessThan(1, 8, 0)) {
+                output.put("CustomName", JsonTextUtil.toLegacy(value.getCustomName(), false));
+            } else {
+                output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            }
         }
     }
 }

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyContainerBlockEntityHandler.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyContainerBlockEntityHandler.java
@@ -68,7 +68,11 @@ public class JavaLegacyContainerBlockEntityHandler extends BlockEntityHandler<Ja
         output.put("Items", items);
 
         if (value.getCustomName() != null) {
-            output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            if (resolvers.dataVersion().getVersion().isLessThan(1, 8, 0)) {
+                output.put("CustomName", JsonTextUtil.toLegacy(value.getCustomName(), false));
+            } else {
+                output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            }
         }
     }
 }

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyEnchantmentBlockEntityHandler.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/blockentity/legacy/handlers/JavaLegacyEnchantmentBlockEntityHandler.java
@@ -25,7 +25,11 @@ public class JavaLegacyEnchantmentBlockEntityHandler extends BlockEntityHandler<
     @Override
     public void write(@NotNull JavaResolvers resolvers, @NotNull CompoundTag output, @NotNull EnchantmentTableBlockEntity value) {
         if (value.getCustomName() != null) {
-            output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            if (resolvers.dataVersion().getVersion().isLessThan(1, 8, 0)) {
+                output.put("CustomName", JsonTextUtil.toLegacy(value.getCustomName(), false));
+            } else {
+                output.put("CustomName", JsonTextUtil.toJSON(value.getCustomName()));
+            }
         }
     }
 }

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/entity/legacy/handlers/JavaLegacyItemFrameEntityHandler.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/entity/legacy/handlers/JavaLegacyItemFrameEntityHandler.java
@@ -28,7 +28,14 @@ public class JavaLegacyItemFrameEntityHandler extends EntityHandler<JavaResolver
         value.setItemRotation(input.getByte("ItemRotation", (byte) 0));
 
         // Facing
-        String name = input.contains("facing") ? "facing" : "Facing";
+        String name;
+        if (input.contains("facing")) {
+            name = "facing";
+        } else if (input.contains("Facing")) {
+            name = "Facing";
+        } else {
+            name = "Direction";
+        }
         value.setDirection(FacingDirection.from2DByte(input.getByte(name, (byte) 0)));
     }
 
@@ -43,6 +50,10 @@ public class JavaLegacyItemFrameEntityHandler extends EntityHandler<JavaResolver
         output.put("ItemRotation", value.getItemRotation());
 
         // Write facing
-        output.put("Facing", value.getDirection().to2DByte());
+        if (resolvers.dataVersion().getVersion().isLessThan(1, 8, 0)) {
+            output.put("Direction", value.getDirection().to2DByte());
+        } else {
+            output.put("Facing", value.getDirection().to2DByte());
+        }
     }
 }

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/entity/legacy/handlers/JavaLegacyPaintingEntityHandler.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/entity/legacy/handlers/JavaLegacyPaintingEntityHandler.java
@@ -25,13 +25,24 @@ public class JavaLegacyPaintingEntityHandler extends EntityHandler<JavaResolvers
         value.setMotive(resolvers.readPaintingMotive(motive));
 
         // Facing
-        String name = input.contains("facing") ? "facing" : "Facing";
+        String name;
+        if (input.contains("facing")) {
+            name = "facing";
+        } else if (input.contains("Facing")) {
+            name = "Facing";
+        } else {
+            name = "Direction";
+        }
         value.setDirection(FacingDirectionHorizontal.from2DByte(input.getByte(name, (byte) 0)));
     }
 
     @Override
     public void write(@NotNull JavaResolvers resolvers, @NotNull CompoundTag output, @NotNull PaintingEntity value) {
         output.put("Motive", resolvers.writePaintingMotive(value.getMotive()));
-        output.put("Facing", value.getDirection() == null ? 0 : value.getDirection().to2DByte());
+        if (resolvers.dataVersion().getVersion().isLessThan(1, 8, 0)) {
+            output.put("Direction", value.getDirection() == null ? 0 : value.getDirection().to2DByte());
+        } else {
+            output.put("Facing", value.getDirection() == null ? 0 : value.getDirection().to2DByte());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support legacy text format for block entity custom names when converting 1.7 worlds
- handle `Direction` orientation for legacy hanging entities

## Testing
- `./gradlew test` *(fails: Toolchain requires JDK, build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_687c5e90ae048323b656758243dd8c8f