### PR TITLE
Improve level convert mappings parser

### DIFF
--- a/cli/src/test/java/com/hivemc/chunker/mapping/LevelConvertMappingsParserTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/mapping/LevelConvertMappingsParserTest.java
@@ -88,4 +88,16 @@ public class LevelConvertMappingsParserTest {
         ));
         assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
     }
+
+    @Test
+    public void testNumericOldIdentifierConversion() throws Exception {
+        File mapping = File.createTempFile("simpleNum", ".txt");
+        mapping.deleteOnExit();
+        Files.writeString(mapping.toPath(), "240 -> uptodate:glazed_terracotta_lime\n");
+
+        MappingsFile mappingsFile = LevelConvertMappingsParser.parse(mapping.toPath(), null);
+        Identifier input = new Identifier("minecraft:lime_glazed_terracotta", Map.of());
+        Identifier expected = new Identifier("uptodate:glazed_terracotta_lime", Map.of());
+        assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
+    }
 }


### PR DESCRIPTION
## Summary
- extend `LevelConvertMappingsParser` to handle plain numeric IDs and allow null level.dat
- convert numeric IDs to modern identifiers via `JavaLegacyBlockIDResolver`
- add regression test for numeric ID input

## Testing
- `./gradlew test` *(fails: environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_687c8e6029f483239658f9192d4fc381