### PR TITLE
Add legacy simple mapping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Additionally, the following parameters are supported:
   this is only supported where the output format is the same as the input and for optimal results you will want to copy
   the input world to the output folder prior to conversion.
 - `--enableNEIDs` - enable NotEnoughIDs formatting (the `Blocks16` tag) when converting to legacy Java worlds.
+- `--legacySimpleMappings` - apply simple block mappings after flattening using legacy identifiers. Only supported when the destination is Java 1.12 or lower.
 
 You can export settings for your world by using the web interface on `https://chunker.app` through the Advanced
 Settings -> Converter Settings tab, the CLI also supports preloading settings from the input directory.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Additionally, the following parameters are supported:
   this is only supported where the output format is the same as the input and for optimal results you will want to copy
   the input world to the output folder prior to conversion.
 - `--enableNEIDs` - enable NotEnoughIDs formatting (the `Blocks16` tag) when converting to legacy Java worlds.
-- `--legacySimpleMappings` - apply simple block mappings after flattening using legacy identifiers. Only supported when the destination is Java 1.12 or lower.
+- `--legacySimpleMappings` - apply simple block mappings after flattening using legacy identifiers. When converting to a legacy version with a simple mapping file this is enabled automatically.
 
 You can export settings for your world by using the web interface on `https://chunker.app` through the Advanced
 Settings -> Converter Settings tab, the CLI also supports preloading settings from the input directory.

--- a/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
+++ b/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
@@ -140,6 +140,12 @@ public class CLI implements Runnable {
     )
     private boolean enableNEIDs;
 
+    @CommandLine.Option(
+            names = {"--legacySimpleMappings"},
+            description = "Apply simple mappings after flattening using legacy identifiers (IDs or ID:META)."
+    )
+    private boolean legacySimpleMappings;
+
     /**
      * Merge two mappings files by appending the identifier list from the second
      * to the first. This is primarily used so simple mappings can extend a JSON
@@ -410,6 +416,15 @@ public class CLI implements Runnable {
 
                 // Enable NotEnoughIDs support so the writer will include Blocks16 like mIDas Platinum.
                 worldConverter.setNotEnoughIDs(true);
+            }
+
+            if (legacySimpleMappings) {
+                if (writer.get().getEncodingType() != EncodingType.JAVA || !writer.get().getVersion().isLessThan(1, 13, 0)) {
+                    System.err.println("--legacySimpleMappings is only supported when converting to legacy Java versions (1.12 or lower). Please remove the flag to continue.");
+                    System.exit(0);
+                }
+
+                worldConverter.setLegacySimpleMappings(true);
             }
 
             // Add the handler for the compaction signal

--- a/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
+++ b/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
@@ -146,6 +146,10 @@ public class CLI implements Runnable {
     )
     private boolean legacySimpleMappings;
 
+    // Track whether simple mappings were provided so we can automatically
+    // enable legacy mapping behaviour for legacy outputs.
+    private boolean simpleMappingsProvided;
+
     /**
      * Merge two mappings files by appending the identifier list from the second
      * to the first. This is primarily used so simple mappings can extend a JSON
@@ -243,6 +247,7 @@ public class CLI implements Runnable {
                     } else {
                         mappingsFile = SimpleMappingsParser.parse(simpleBlockMappings.toPath());
                     }
+                    simpleMappingsProvided = true;
                     if (loadedMappings == null) {
                         loadedMappings = mappingsFile;
                     } else {
@@ -424,6 +429,10 @@ public class CLI implements Runnable {
                     System.exit(0);
                 }
 
+                worldConverter.setLegacySimpleMappings(true);
+            } else if (simpleMappingsProvided && writer.get().getEncodingType() == EncodingType.JAVA && writer.get().getVersion().isLessThan(1, 13, 0)) {
+                // Automatically enable legacy simple mappings when converting to legacy
+                // versions using a simple mapping file.
                 worldConverter.setLegacySimpleMappings(true);
             }
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/WorldConverter.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/WorldConverter.java
@@ -90,6 +90,7 @@ public class WorldConverter implements Converter {
     private boolean discardEmptyChunks = false;
     private boolean preventYBiomeBlending = false;
     private boolean notEnoughIDs = false;
+    private boolean legacySimpleMappings = false;
     private boolean customIdentifiers = true;
     private boolean exceptions = false;
     private boolean cancelled = false;
@@ -169,6 +170,15 @@ public class WorldConverter implements Converter {
      */
     public void setNotEnoughIDs(boolean notEnoughIDs) {
         this.notEnoughIDs = notEnoughIDs;
+    }
+
+    /**
+     * Set whether simple mappings should be applied using legacy identifiers.
+     *
+     * @param legacySimpleMappings true if legacy simple mappings are enabled.
+     */
+    public void setLegacySimpleMappings(boolean legacySimpleMappings) {
+        this.legacySimpleMappings = legacySimpleMappings;
     }
 
     /**
@@ -338,6 +348,11 @@ public class WorldConverter implements Converter {
     @Override
     public boolean shouldUseNotEnoughIDs() {
         return notEnoughIDs;
+    }
+
+    @Override
+    public boolean shouldUseLegacySimpleMappings() {
+        return legacySimpleMappings;
     }
 
     @Override

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/Converter.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/Converter.java
@@ -178,6 +178,16 @@ public interface Converter {
     }
 
     /**
+     * Whether simple mappings should be applied after flattening using legacy
+     * identifiers (ID or ID:meta) for modern to legacy conversions.
+     *
+     * @return true if legacy simple mappings are enabled.
+     */
+    default boolean shouldUseLegacySimpleMappings() {
+        return false;
+    }
+
+    /**
      * Get the dimension mapping given an input.
      *
      * @param dimension the input dimension.

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -332,11 +332,12 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
             Optional<Identifier> mapped = mappingsFileResolvers.getMappings().convertBlock(output.get());
             if (mapped.isPresent()) {
                 Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(mapped.get().getStates());
+
+                // Preserve any states from the flattened output that were not explicitly set by the mapping
                 for (Map.Entry<String, StateValue<?>> entry : output.get().getStates().entrySet()) {
-                    if (MappingsFile.isSpecialState(entry.getKey()) && !states.containsKey(entry.getKey())) {
-                        states.put(entry.getKey(), entry.getValue());
-                    }
+                    states.putIfAbsent(entry.getKey(), entry.getValue());
                 }
+
                 output = Optional.of(new Identifier(mapped.get().getIdentifier(), states));
             }
         }

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -15,6 +15,7 @@ import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.b
 import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.BlockStateValue;
 import com.hivemc.chunker.mapping.identifier.Identifier;
 import com.hivemc.chunker.mapping.identifier.states.StateValue;
+import com.hivemc.chunker.mapping.MappingsFile;
 import com.hivemc.chunker.mapping.resolver.MappingsFileResolvers;
 import com.hivemc.chunker.resolver.Resolver;
 import com.hivemc.chunker.util.CollectionComparator;
@@ -324,7 +325,23 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
      * @return the output with any user mappings applied.
      */
     protected Optional<Identifier> handleConverterMapping(ChunkerBlockIdentifier input, Optional<Identifier> output) {
-        // If there is no preserved identifier, return the original
+        MappingsFileResolvers mappingsFileResolvers = converter.getBlockMappings();
+
+        // Apply legacy simple mappings to the output identifier when no preserved mapping is set
+        if (input.getPreservedIdentifier() == null && mappingsFileResolvers != null && converter.shouldUseLegacySimpleMappings() && output.isPresent()) {
+            Optional<Identifier> mapped = mappingsFileResolvers.getMappings().convertBlock(output.get());
+            if (mapped.isPresent()) {
+                Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(mapped.get().getStates());
+                for (Map.Entry<String, StateValue<?>> entry : output.get().getStates().entrySet()) {
+                    if (MappingsFile.isSpecialState(entry.getKey()) && !states.containsKey(entry.getKey())) {
+                        states.put(entry.getKey(), entry.getValue());
+                    }
+                }
+                output = Optional.of(new Identifier(mapped.get().getIdentifier(), states));
+            }
+        }
+
+        // If there is no preserved identifier, return the original (or legacy mapped output)
         // Otherwise if the preserved identifier is the same as this, don't apply it as it's for the writer
         if (input.getPreservedIdentifier() == null || reader == input.getPreservedIdentifier().fromReader())
             return output;

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -39,6 +39,9 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
     protected final Map<String, InputStateGrouping<String, Object, ChunkerBlockType, BlockState<?>, BlockStateValue>> inputToChunker = new Object2ObjectOpenHashMap<>();
     protected final Map<ChunkerBlockType, InputStateGrouping<BlockState<?>, BlockStateValue, String, String, Object>> chunkerToInput = new Object2ObjectOpenHashMap<>();
     protected StateMappingGroup extraStateMappingGroup;
+    /** Resolver used for legacy simple mappings when the target version lacks a mapping. */
+    @Nullable
+    protected ChunkerBlockIdentifierResolver legacySimpleResolver;
 
     /**
      * Create a new chunker block identifier resolver.
@@ -290,6 +293,18 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
     }
 
     /**
+     * Attempt to resolve the input using a legacy 1.12 resolver. This is used
+     * for legacy simple mappings when the target version does not contain a
+     * direct mapping for the block.
+     *
+     * @param input the input block identifier.
+     * @return the resolved identifier if available.
+     */
+    protected Optional<Identifier> legacyResolveFrom(ChunkerBlockIdentifier input) {
+        return legacySimpleResolver == null ? Optional.empty() : legacySimpleResolver.resolveFrom(input);
+    }
+
+    /**
      * Handle any user input identifier conversion mappings.
      *
      * @param input  the original input.
@@ -328,17 +343,20 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
         MappingsFileResolvers mappingsFileResolvers = converter.getBlockMappings();
 
         // Apply legacy simple mappings to the output identifier when no preserved mapping is set
-        if (input.getPreservedIdentifier() == null && mappingsFileResolvers != null && converter.shouldUseLegacySimpleMappings() && output.isPresent()) {
-            Optional<Identifier> mapped = mappingsFileResolvers.getMappings().convertBlock(output.get());
-            if (mapped.isPresent()) {
-                Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(mapped.get().getStates());
+        if (input.getPreservedIdentifier() == null && mappingsFileResolvers != null && converter.shouldUseLegacySimpleMappings()) {
+            Optional<Identifier> base = output.isPresent() ? output : legacyResolveFrom(input);
+            if (base.isPresent()) {
+                Optional<Identifier> mapped = mappingsFileResolvers.getMappings().convertBlock(base.get());
+                if (mapped.isPresent()) {
+                    Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(mapped.get().getStates());
 
-                // Preserve any states from the flattened output that were not explicitly set by the mapping
-                for (Map.Entry<String, StateValue<?>> entry : output.get().getStates().entrySet()) {
-                    states.putIfAbsent(entry.getKey(), entry.getValue());
+                    // Preserve any states from the flattened output that were not explicitly set by the mapping
+                    for (Map.Entry<String, StateValue<?>> entry : base.get().getStates().entrySet()) {
+                        states.putIfAbsent(entry.getKey(), entry.getValue());
+                    }
+
+                    output = Optional.of(new Identifier(mapped.get().getIdentifier(), states));
                 }
-
-                output = Optional.of(new Identifier(mapped.get().getIdentifier(), states));
             }
         }
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIdentifierResolver.java
@@ -38,6 +38,12 @@ public class JavaLegacyBlockIdentifierResolver extends ChunkerBlockIdentifierRes
      */
     public JavaLegacyBlockIdentifierResolver(Converter converter, Version version, boolean reader, boolean customIdentifiersAllowed) {
         super(converter, version, reader, customIdentifiersAllowed);
+
+        // When targeting versions older than 1.8, create a resolver for 1.12.2
+        // so legacy simple mappings can flatten newer blocks.
+        if (version.isLessThan(1, 8, 0)) {
+            legacySimpleResolver = new JavaLegacyBlockIdentifierResolver(converter, new Version(1, 12, 2), reader, customIdentifiersAllowed);
+        }
     }
 
     @Override

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -1,0 +1,62 @@
+package com.hivemc.chunker.conversion.java.resolver.legacy;
+
+import com.hivemc.chunker.conversion.bedrock.resolver.MockConverter;
+import com.hivemc.chunker.conversion.encoding.base.Version;
+import com.hivemc.chunker.conversion.encoding.java.base.resolver.identifier.legacy.JavaLegacyBlockIdentifierResolver;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.ChunkerBlockIdentifier;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.ChunkerVanillaBlockType;
+import com.hivemc.chunker.mapping.MappingsFile;
+import com.hivemc.chunker.mapping.identifier.Identifier;
+import com.hivemc.chunker.mapping.parser.SimpleMappingsParser;
+import com.hivemc.chunker.mapping.resolver.MappingsFileResolvers;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Tests for the legacy simple mappings feature. */
+public class JavaLegacySimpleMappingsTest {
+
+    @Test
+    public void testLegacySimpleMappingApplied() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:red_sandstone_stairs -> custom:rs_stairs\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 12, 2), false, false);
+
+        Optional<Identifier> result = resolver.from(new ChunkerBlockIdentifier(ChunkerVanillaBlockType.RED_SANDSTONE_STAIRS));
+        assertTrue(result.isPresent());
+        assertEquals("custom:rs_stairs", result.get().getIdentifier());
+    }
+
+    @Test
+    public void testLegacyMappingIgnoredByDefault() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:red_sandstone_stairs -> custom:rs_stairs\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 12, 2), false, false);
+
+        Optional<Identifier> result = resolver.from(new ChunkerBlockIdentifier(ChunkerVanillaBlockType.RED_SANDSTONE_STAIRS));
+        assertTrue(result.isPresent());
+        assertEquals("minecraft:red_sandstone_stairs", result.get().getIdentifier());
+    }
+}
+

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -92,5 +92,34 @@ public class JavaLegacySimpleMappingsTest {
         assertTrue(result.isPresent());
         assertEquals("minecraft:red_sandstone_stairs", result.get().getIdentifier());
     }
+
+    @Test
+    public void testLegacyMappingWithOlderTargetVersion() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:spruce_fence_gate -> custom:sfg\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 7, 10), false, false);
+
+        ChunkerBlockIdentifier input = new ChunkerBlockIdentifier(
+                ChunkerVanillaBlockType.SPRUCE_FENCE_GATE,
+                Map.of(
+                        VanillaBlockStates.FACING_HORIZONTAL, FacingDirectionHorizontal.EAST,
+                        VanillaBlockStates.OPEN, Bool.TRUE,
+                        VanillaBlockStates.POWERED, Bool.FALSE
+                )
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("custom:sfg", result.get().getIdentifier());
+    }
 }
 

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -8,6 +8,8 @@ import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.b
 import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.VanillaBlockStates;
 import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.types.Bool;
 import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.types.FacingDirectionHorizontal;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.types.FacingDirection;
+import com.hivemc.chunker.mapping.identifier.states.StateValueInt;
 import com.hivemc.chunker.mapping.MappingsFile;
 import com.hivemc.chunker.mapping.identifier.Identifier;
 import com.hivemc.chunker.mapping.parser.SimpleMappingsParser;
@@ -120,6 +122,32 @@ public class JavaLegacySimpleMappingsTest {
         Optional<Identifier> result = resolver.from(input);
         assertTrue(result.isPresent());
         assertEquals("custom:sfg", result.get().getIdentifier());
+    }
+
+    @Test
+    public void testEndRodPreservesOrientationOnOlderTarget() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:end_rod -> custom:er\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 7, 10), false, false);
+
+        ChunkerBlockIdentifier input = new ChunkerBlockIdentifier(
+                ChunkerVanillaBlockType.END_ROD,
+                Map.of(VanillaBlockStates.FACING_ALL, FacingDirection.EAST)
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("custom:er", result.get().getIdentifier());
+        assertEquals(5, ((StateValueInt) result.get().getStates().get("data")).getValue());
     }
 }
 


### PR DESCRIPTION
## Summary
- add `legacySimpleMappings` option for post-flatten mappings
- implement flag in CLI and `WorldConverter`
- apply legacy mapping logic in `ChunkerBlockIdentifierResolver`
- document new flag in README
- test legacy simple mappings

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_687f07e091588323844d4a41018218b8