### PR TITLE
Add legacy simple mapping fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Additionally, the following parameters are supported:
   this is only supported where the output format is the same as the input and for optimal results you will want to copy
   the input world to the output folder prior to conversion.
 - `--enableNEIDs` - enable NotEnoughIDs formatting (the `Blocks16` tag) when converting to legacy Java worlds.
+- `--legacySimpleMappings` - apply simple block mappings after flattening using legacy identifiers. When converting to a legacy version with a simple mapping file this is enabled automatically.
 
 You can export settings for your world by using the web interface on `https://chunker.app` through the Advanced
 Settings -> Converter Settings tab, the CLI also supports preloading settings from the input directory.

--- a/cli/src/main/java/com/hivemc/chunker/conversion/WorldConverter.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/WorldConverter.java
@@ -90,6 +90,7 @@ public class WorldConverter implements Converter {
     private boolean discardEmptyChunks = false;
     private boolean preventYBiomeBlending = false;
     private boolean notEnoughIDs = false;
+    private boolean legacySimpleMappings = false;
     private boolean customIdentifiers = true;
     private boolean exceptions = false;
     private boolean cancelled = false;
@@ -169,6 +170,15 @@ public class WorldConverter implements Converter {
      */
     public void setNotEnoughIDs(boolean notEnoughIDs) {
         this.notEnoughIDs = notEnoughIDs;
+    }
+
+    /**
+     * Set whether simple mappings should be applied using legacy identifiers.
+     *
+     * @param legacySimpleMappings true if legacy simple mappings are enabled.
+     */
+    public void setLegacySimpleMappings(boolean legacySimpleMappings) {
+        this.legacySimpleMappings = legacySimpleMappings;
     }
 
     /**
@@ -338,6 +348,11 @@ public class WorldConverter implements Converter {
     @Override
     public boolean shouldUseNotEnoughIDs() {
         return notEnoughIDs;
+    }
+
+    @Override
+    public boolean shouldUseLegacySimpleMappings() {
+        return legacySimpleMappings;
     }
 
     @Override

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/Converter.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/Converter.java
@@ -178,6 +178,16 @@ public interface Converter {
     }
 
     /**
+     * Whether simple mappings should be applied after flattening using legacy
+     * identifiers (ID or ID:meta) for modern to legacy conversions.
+     *
+     * @return true if legacy simple mappings are enabled.
+     */
+    default boolean shouldUseLegacySimpleMappings() {
+        return false;
+    }
+
+    /**
      * Get the dimension mapping given an input.
      *
      * @param dimension the input dimension.

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIdentifierResolver.java
@@ -38,6 +38,12 @@ public class JavaLegacyBlockIdentifierResolver extends ChunkerBlockIdentifierRes
      */
     public JavaLegacyBlockIdentifierResolver(Converter converter, Version version, boolean reader, boolean customIdentifiersAllowed) {
         super(converter, version, reader, customIdentifiersAllowed);
+
+        // When targeting versions older than 1.8, create a resolver for 1.12.2
+        // so legacy simple mappings can flatten newer blocks.
+        if (version.isLessThan(1, 8, 0)) {
+            legacySimpleResolver = new JavaLegacyBlockIdentifierResolver(converter, new Version(1, 12, 2), reader, customIdentifiersAllowed);
+        }
     }
 
     @Override

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -125,6 +125,36 @@ public class JavaLegacySimpleMappingsTest {
     }
 
     @Test
+    public void testFenceGateOrientationOnOlderTarget() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:spruce_fence_gate -> custom:sfg\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 7, 10), false, false);
+
+        ChunkerBlockIdentifier input = new ChunkerBlockIdentifier(
+                ChunkerVanillaBlockType.SPRUCE_FENCE_GATE,
+                Map.of(
+                        VanillaBlockStates.FACING_HORIZONTAL, FacingDirectionHorizontal.WEST,
+                        VanillaBlockStates.OPEN, Bool.TRUE,
+                        VanillaBlockStates.POWERED, Bool.FALSE
+                )
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("custom:sfg", result.get().getIdentifier());
+        assertEquals(5, ((StateValueInt) result.get().getStates().get("data")).getValue());
+    }
+
+    @Test
     public void testEndRodPreservesOrientationOnOlderTarget() throws Exception {
         File simple = File.createTempFile("simple", ".txt");
         simple.deleteOnExit();

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -1,0 +1,153 @@
+package com.hivemc.chunker.conversion.java.resolver.legacy;
+
+import com.hivemc.chunker.conversion.bedrock.resolver.MockConverter;
+import com.hivemc.chunker.conversion.encoding.base.Version;
+import com.hivemc.chunker.conversion.encoding.java.base.resolver.identifier.legacy.JavaLegacyBlockIdentifierResolver;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.ChunkerBlockIdentifier;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.ChunkerVanillaBlockType;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.VanillaBlockStates;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.types.Bool;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.types.FacingDirectionHorizontal;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.types.FacingDirection;
+import com.hivemc.chunker.mapping.identifier.states.StateValueInt;
+import com.hivemc.chunker.mapping.MappingsFile;
+import com.hivemc.chunker.mapping.identifier.Identifier;
+import com.hivemc.chunker.mapping.parser.SimpleMappingsParser;
+import com.hivemc.chunker.mapping.resolver.MappingsFileResolvers;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Tests for the legacy simple mappings feature. */
+public class JavaLegacySimpleMappingsTest {
+
+    @Test
+    public void testLegacySimpleMappingApplied() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:red_sandstone_stairs -> custom:rs_stairs\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 12, 2), false, false);
+
+        Optional<Identifier> result = resolver.from(new ChunkerBlockIdentifier(ChunkerVanillaBlockType.RED_SANDSTONE_STAIRS));
+        assertTrue(result.isPresent());
+        assertEquals("custom:rs_stairs", result.get().getIdentifier());
+    }
+
+    @Test
+    public void testLegacyMappingPreservesStates() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:spruce_fence_gate -> custom:sfg\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 12, 2), false, false);
+
+        ChunkerBlockIdentifier input = new ChunkerBlockIdentifier(
+                ChunkerVanillaBlockType.SPRUCE_FENCE_GATE,
+                Map.of(
+                        VanillaBlockStates.FACING_HORIZONTAL, FacingDirectionHorizontal.EAST,
+                        VanillaBlockStates.OPEN, Bool.TRUE,
+                        VanillaBlockStates.POWERED, Bool.FALSE
+                )
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("custom:sfg", result.get().getIdentifier());
+        assertNotNull(result.get().getStates().get("data"));
+    }
+
+    @Test
+    public void testLegacyMappingIgnoredByDefault() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:red_sandstone_stairs -> custom:rs_stairs\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 12, 2), false, false);
+
+        Optional<Identifier> result = resolver.from(new ChunkerBlockIdentifier(ChunkerVanillaBlockType.RED_SANDSTONE_STAIRS));
+        assertTrue(result.isPresent());
+        assertEquals("minecraft:red_sandstone_stairs", result.get().getIdentifier());
+    }
+
+    @Test
+    public void testLegacyMappingWithOlderTargetVersion() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:spruce_fence_gate -> custom:sfg\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 7, 10), false, false);
+
+        ChunkerBlockIdentifier input = new ChunkerBlockIdentifier(
+                ChunkerVanillaBlockType.SPRUCE_FENCE_GATE,
+                Map.of(
+                        VanillaBlockStates.FACING_HORIZONTAL, FacingDirectionHorizontal.EAST,
+                        VanillaBlockStates.OPEN, Bool.TRUE,
+                        VanillaBlockStates.POWERED, Bool.FALSE
+                )
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("custom:sfg", result.get().getIdentifier());
+    }
+
+    @Test
+    public void testEndRodPreservesOrientationOnOlderTarget() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:end_rod -> custom:er\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 7, 10), false, false);
+
+        ChunkerBlockIdentifier input = new ChunkerBlockIdentifier(
+                ChunkerVanillaBlockType.END_ROD,
+                Map.of(VanillaBlockStates.FACING_ALL, FacingDirection.EAST)
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("custom:er", result.get().getIdentifier());
+        assertEquals(5, ((StateValueInt) result.get().getStates().get("data")).getValue());
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow fallback to 1.12 mappings for legacy simple mappings
- instantiate fallback resolver for versions older than 1.8
- test mapping on 1.7.10 output
- automatically enable legacy simple mappings when converting with a simple file
- verify orientation for end rod mappings

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687f07e091588323844d4a41018218b8