### PR TITLE
Ensure legacy simple mappings carry metadata

### DIFF
--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -179,5 +179,31 @@ public class JavaLegacySimpleMappingsTest {
         assertEquals("custom:er", result.get().getIdentifier());
         assertEquals(5, ((StateValueInt) result.get().getStates().get("data")).getValue());
     }
+
+    @Test
+    public void testEndRodModdedMappingPreservesOrientation() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:end_rod -> etfuturum:end_rod\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 7, 10), false, false);
+
+        ChunkerBlockIdentifier input = new ChunkerBlockIdentifier(
+                ChunkerVanillaBlockType.END_ROD,
+                Map.of(VanillaBlockStates.FACING_ALL, FacingDirection.EAST)
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("etfuturum:end_rod", result.get().getIdentifier());
+        assertEquals(5, ((StateValueInt) result.get().getStates().get("data")).getValue());
+    }
 }
 


### PR DESCRIPTION
## Summary
- ensure metadata from legacy blocks is preferred when applying simple mappings
- add test verifying modded mapping preserves orientation

## Testing
- `./gradlew :cli:test --tests "*JavaLegacySimpleMappingsTest*" --no-daemon --console=plain --info --rerun-tasks`

------
https://chatgpt.com/codex/tasks/task_e_687f41a041c4832389b9d2a9cf15513b