### PR TITLE
Ensure legacy mappings always keep metadata

### DIFF
--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -345,6 +345,10 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
         // Apply legacy simple mappings to the output identifier when no preserved mapping is set
         if (input.getPreservedIdentifier() == null && mappingsFileResolvers != null && converter.shouldUseLegacySimpleMappings()) {
             Optional<Identifier> base = output.isPresent() ? output : legacyResolveFrom(input);
+            if (base.isEmpty()) {
+                // Fall back to using the raw custom identifier when no legacy mapping exists
+                base = handleFallback(input);
+            }
             if (base.isPresent()) {
                 Optional<Identifier> mapped = mappingsFileResolvers.getMappings().convertBlock(base.get());
                 if (mapped.isPresent()) {

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -350,10 +350,9 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
                 if (mapped.isPresent()) {
                     Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(mapped.get().getStates());
 
-                    // Preserve any states from the flattened output that were not explicitly set by the mapping
-                    for (Map.Entry<String, StateValue<?>> entry : base.get().getStates().entrySet()) {
-                        states.putIfAbsent(entry.getKey(), entry.getValue());
-                    }
+                    // Force any states from the flattened output onto the mapping
+                    // so legacy metadata such as orientation is always preserved.
+                    states.putAll(base.get().getStates());
 
                     output = Optional.of(new Identifier(mapped.get().getIdentifier(), states));
                 }

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -179,5 +179,32 @@ public class JavaLegacySimpleMappingsTest {
         assertEquals("custom:er", result.get().getIdentifier());
         assertEquals(5, ((StateValueInt) result.get().getStates().get("data")).getValue());
     }
+
+    @Test
+    public void testMappingForcesBaseData() throws Exception {
+        File simple = File.createTempFile("simple", ".txt");
+        simple.deleteOnExit();
+        Files.writeString(simple.toPath(), "minecraft:end_rod -> custom:er[data=0]\n");
+
+        MappingsFile mappings = SimpleMappingsParser.parse(simple.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 7, 10), false, false);
+
+        ChunkerBlockIdentifier input = new ChunkerBlockIdentifier(
+                ChunkerVanillaBlockType.END_ROD,
+                Map.of(VanillaBlockStates.FACING_ALL, FacingDirection.WEST)
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("custom:er", result.get().getIdentifier());
+        // The data from the input (facing west -> 4) should override the mapping
+        assertEquals(4, ((StateValueInt) result.get().getStates().get("data")).getValue());
+    }
 }
 


### PR DESCRIPTION
## Summary
- keep metadata when applying legacy simple mappings by always overriding states with those from the flattened block
- test overriding explicit `data` with the block's orientation metadata

## Testing
- `./gradlew test --tests "com.hivemc.chunker.conversion.java.resolver.legacy.JavaLegacySimpleMappingsTest"`

------
https://chatgpt.com/codex/tasks/task_e_687f41a041c4832389b9d2a9cf15513b