### PR TITLE
Fix legacy simple mappings with level convert

### DIFF
--- a/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
+++ b/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
@@ -268,7 +268,6 @@ public class CLI implements Runnable {
             if (simpleBlockMappings != null) {
                 try {
                     if (levelConvert != null) {
-                        System.out.print("Beginning Level Convert");
                         LevelConvertMappings.load(levelConvert);
                     }
                     MappingsFile mappingsFile = SimpleMappingsParser.parse(simpleBlockMappings.toPath());


### PR DESCRIPTION
## Summary
- ensure legacy simple mappings use legacy identifier for lookup but preserve modern data
- drop debug print from CLI when loading level.dat

## Testing
- `./gradlew test --tests "com.hivemc.chunker.conversion.java.resolver.legacy.JavaLegacySimpleMappingsTest"`

------
https://chatgpt.com/codex/tasks/task_e_687ff7aca1e4832388aff1d29c732d65