### PR TITLE
Add numeric ID support for level convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Additionally, the following parameters are supported:
 
 - `-m` / `--blockMappings` - a path to a json file or a json object containing block mappings.
 - `-sm` / `--simpleBlockMappings` - a path to a text file containing simple mappings in the form `old[state=value] -> new[state=value]`. State values are case sensitive; enumerated values such as directions should be written in upper case (e.g. `facing=WEST`). When provided alongside `--blockMappings` the entries are appended to the JSON mappings.
-- `--levelConvert` - when used with `--simpleBlockMappings` resolves the output identifiers using a provided legacy `level.dat` file. Only supported when the destination format is Java 1.12 or lower.
+- `--levelConvert` - when used with `--simpleBlockMappings` resolves the output identifiers using a provided legacy `level.dat` file. When the level contains numeric IDs these are written directly, preserving metadata. Only supported when the destination format is Java 1.12 or lower.
 - `--generateSimpleMappingsTemplate` - write an example simple mapping file to the given path and exit.
 - `--convertMapping` - parse a simple mapping file (optionally with `--levelConvert`) and write `generated.json` next to the input file, then exit.
 - For a more comprehensive example containing both JSON and simple mapping formats run `java -cp chunker.jar com.hivemc.chunker.mapping.parser.ComplexMappingsTemplateGenerator <dir>` and the templates will be written to the specified directory.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Additionally, the following parameters are supported:
   the input world to the output folder prior to conversion.
 - `--enableNEIDs` - enable NotEnoughIDs formatting (the `Blocks16` tag) when converting to legacy Java worlds.
 - `--legacySimpleMappings` - apply simple block mappings after flattening using legacy identifiers. When converting to a legacy version with a simple mapping file this is enabled automatically.
+- `--debug` - enable verbose logging to the console and write a `conversion.log` file in the output directory.
 
 You can export settings for your world by using the web interface on `https://chunker.app` through the Advanced
 Settings -> Converter Settings tab, the CLI also supports preloading settings from the input directory.

--- a/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
+++ b/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
@@ -400,6 +400,14 @@ public class CLI implements Runnable {
             // Check for the original NBT option
             worldConverter.setAllowNBTCopying(keepOriginalNBT);
 
+            // Enable legacy simple mappings prior to resolver construction so
+            // the writer can apply them correctly. This is normally set again
+            // after validation below but needs to be enabled before creating
+            // the reader and writer.
+            if (legacySimpleMappings || (simpleMappingsProvided && format.toLowerCase().startsWith("java"))) {
+                worldConverter.setLegacySimpleMappings(true);
+            }
+
             // Create the reader / writer (note: converter settings cannot be set after this point)
             Optional<? extends LevelReader> reader = EncodingType.findReader(inputDirectory, worldConverter);
             Optional<? extends LevelWriter> writer = Messenger.findWriter(format, worldConverter, outputDirectory);

--- a/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
+++ b/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
@@ -206,6 +206,7 @@ public class CLI implements Runnable {
 
     @Override
     public void run() {
+        WorldConverter worldConverter = null;
         try {
             // Create the converter
             Stopwatch stopwatch = Stopwatch.createStarted();
@@ -248,8 +249,10 @@ public class CLI implements Runnable {
             }
 
             // Create the converter
-            WorldConverter worldConverter = new WorldConverter(UUID.randomUUID());
+            worldConverter = new WorldConverter(UUID.randomUUID());
             worldConverter.setDebug(debug);
+            File logFile = new File(outputDirectory, "conversion.log");
+            worldConverter.setLogFile(logFile);
             if (levelConvert != null) {
                 worldConverter.setLegacyLevelDat(levelConvert);
             }
@@ -526,6 +529,7 @@ public class CLI implements Runnable {
             if (failed.get() != null) {
                 System.err.println("Failed with exception");
                 failed.get().printStackTrace();
+                worldConverter.closeLogFile();
                 System.exit(1);
             } else {
                 Duration duration = stopwatch.elapsed();
@@ -534,6 +538,7 @@ public class CLI implements Runnable {
                         duration.toSecondsPart(),
                         duration.toMillisPart()
                 ));
+                worldConverter.closeLogFile();
                 System.exit(0);
             }
         } catch (OutOfMemoryError e) {
@@ -544,6 +549,9 @@ public class CLI implements Runnable {
             }
 
             // Use error code 12 for OOM
+            if (worldConverter != null) {
+                worldConverter.closeLogFile();
+            }
             System.exit(12);
         }
     }

--- a/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
+++ b/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
@@ -153,6 +153,12 @@ public class CLI implements Runnable {
     )
     private boolean legacySimpleMappings;
 
+    @CommandLine.Option(
+            names = {"--debug"},
+            description = "Enable verbose debug logging."
+    )
+    private boolean debug;
+
     // Track whether simple mappings were provided so we can automatically
     // enable legacy mapping behaviour for legacy outputs.
     private boolean simpleMappingsProvided;
@@ -222,8 +228,15 @@ public class CLI implements Runnable {
                 try {
                     if (levelConvert != null) {
                         com.hivemc.chunker.mapping.LevelConvertMappings.load(levelConvert);
+                        if (debug) {
+                            System.out.println("[DEBUG] Loaded " + com.hivemc.chunker.mapping.LevelConvertMappings.size() + " level.dat mappings");
+                        }
                     }
                     MappingsFile mappingsFile = SimpleMappingsParser.parse(simpleBlockMappings.toPath());
+                    if (debug) {
+                        int count = mappingsFile.toJson().getAsJsonObject().getAsJsonArray("identifiers").size();
+                        System.out.println("[DEBUG] Parsed " + count + " simple mappings");
+                    }
                     Path outPath = simpleBlockMappings.toPath().getParent().resolve("generated.json");
                     Files.writeString(outPath, mappingsFile.toJsonString());
                     System.out.println("Generated mapping file: " + outPath.toAbsolutePath());
@@ -236,6 +249,7 @@ public class CLI implements Runnable {
 
             // Create the converter
             WorldConverter worldConverter = new WorldConverter(UUID.randomUUID());
+            worldConverter.setDebug(debug);
             if (levelConvert != null) {
                 worldConverter.setLegacyLevelDat(levelConvert);
             }
@@ -269,8 +283,15 @@ public class CLI implements Runnable {
                 try {
                     if (levelConvert != null) {
                         LevelConvertMappings.load(levelConvert);
+                        if (debug) {
+                            System.out.println("[DEBUG] Loaded " + LevelConvertMappings.size() + " level.dat mappings");
+                        }
                     }
                     MappingsFile mappingsFile = SimpleMappingsParser.parse(simpleBlockMappings.toPath());
+                    if (debug) {
+                        int count = mappingsFile.toJson().getAsJsonObject().getAsJsonArray("identifiers").size();
+                        System.out.println("[DEBUG] Parsed " + count + " simple mappings");
+                    }
                     simpleMappingsProvided = true;
                     if (loadedMappings == null) {
                         loadedMappings = mappingsFile;

--- a/cli/src/main/java/com/hivemc/chunker/conversion/WorldConverter.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/WorldConverter.java
@@ -93,6 +93,7 @@ public class WorldConverter implements Converter {
     private boolean notEnoughIDs = false;
     private boolean legacySimpleMappings = false;
     private boolean customIdentifiers = true;
+    private boolean debug = false;
     private boolean exceptions = false;
     private boolean cancelled = false;
     @Nullable
@@ -183,6 +184,24 @@ public class WorldConverter implements Converter {
     }
 
     /**
+     * Enable or disable debug logging.
+     *
+     * @param debug true to enable debugging.
+     */
+    public void setDebug(boolean debug) {
+        this.debug = debug;
+    }
+
+    /**
+     * Check whether debug logging is enabled.
+     *
+     * @return true if debug logging is enabled.
+     */
+    public boolean isDebug() {
+        return debug;
+    }
+
+    /**
      * Set whether items should be converted otherwise air will be used.
      *
      * @param processItems true if they should be converted.
@@ -265,6 +284,7 @@ public class WorldConverter implements Converter {
         if (levelDat != null) {
             try {
                 com.hivemc.chunker.mapping.LevelConvertMappings.load(levelDat);
+                logDebug("Loaded " + com.hivemc.chunker.mapping.LevelConvertMappings.size() + " level.dat mappings");
             } catch (IOException e) {
                 logNonFatalException(e);
             }
@@ -527,6 +547,13 @@ public class WorldConverter implements Converter {
         if (missingIdentifiers.put(type, identifier)) {
             // Log if it's new
             Converter.super.logMissingMapping(type, identifier);
+        }
+    }
+
+    @Override
+    public void logDebug(String message) {
+        if (debug) {
+            System.out.println("[DEBUG] " + message);
         }
     }
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/Converter.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/Converter.java
@@ -153,6 +153,14 @@ public interface Converter {
     }
 
     /**
+     * Log a debug message if debugging is enabled.
+     *
+     * @param message the message to log.
+     */
+    default void logDebug(String message) {
+    }
+
+    /**
      * Whether empty chunks should be discarded instead of written.
      *
      * @return true if chunks should be removed instead of written.

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -491,12 +491,18 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
         Integer legacy = LevelConvertMappings.getLegacyId(ident);
         if (legacy != null) {
             Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(id.getStates());
-            if (!states.containsKey("data") && legacySimpleResolver != null) {
+            if (legacySimpleResolver != null) {
                 Optional<Identifier> legacyData = legacySimpleResolver.resolveFrom(input);
                 if (legacyData.isPresent()) {
                     OptionalInt dv = legacyData.get().getDataValue();
                     if (dv.isPresent()) {
-                        states.put("data", new StateValueInt(dv.getAsInt()));
+                        int val = dv.getAsInt();
+                        StateValue<?> existing = states.get("data");
+                        if (existing == null ||
+                                !(existing instanceof StateValueInt e) ||
+                                e.getValue() == 0 || val != 0) {
+                            states.put("data", new StateValueInt(val));
+                        }
                     }
                 }
             }

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -18,6 +18,7 @@ import com.hivemc.chunker.mapping.identifier.states.StateValue;
 import com.hivemc.chunker.mapping.identifier.states.StateValueInt;
 import com.hivemc.chunker.mapping.MappingsFile;
 import com.hivemc.chunker.mapping.LevelConvertMappings;
+import com.hivemc.chunker.conversion.encoding.java.base.resolver.identifier.legacy.JavaLegacyBlockIdentifierResolver;
 import com.hivemc.chunker.mapping.resolver.MappingsFileResolvers;
 import com.hivemc.chunker.resolver.Resolver;
 import com.hivemc.chunker.util.CollectionComparator;
@@ -491,18 +492,15 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
         Integer legacy = LevelConvertMappings.getLegacyId(ident);
         if (legacy != null) {
             Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(id.getStates());
-            if (legacySimpleResolver != null) {
-                Optional<Identifier> legacyData = legacySimpleResolver.resolveFrom(input);
-                if (legacyData.isPresent()) {
-                    OptionalInt dv = legacyData.get().getDataValue();
-                    if (dv.isPresent()) {
-                        int val = dv.getAsInt();
-                        StateValue<?> existing = states.get("data");
-                        if (existing == null ||
-                                !(existing instanceof StateValueInt e) ||
-                                e.getValue() == 0 || val != 0) {
-                            states.put("data", new StateValueInt(val));
-                        }
+            if (legacySimpleResolver instanceof JavaLegacyBlockIdentifierResolver r) {
+                OptionalInt dv = r.resolveLegacyData(input);
+                if (dv.isPresent()) {
+                    int val = dv.getAsInt();
+                    StateValue<?> existing = states.get("data");
+                    if (existing == null ||
+                            !(existing instanceof StateValueInt e) ||
+                            e.getValue() == 0 || val != 0) {
+                        states.put("data", new StateValueInt(val));
                     }
                 }
             }

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/JavaResolversBuilder.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/JavaResolversBuilder.java
@@ -270,14 +270,18 @@ public class JavaResolversBuilder {
                                 }
                                 id = resolved.get();
                             }
-                            return new LegacyIdentifier(id, (byte) identifier.getDataValue().orElse(0));
+                            LegacyIdentifier legacy = new LegacyIdentifier(id, (byte) identifier.getDataValue().orElse(0));
+                            converter.logDebug("writeLegacyBlockIdentifier " + chunkerBlockIdentifier + " -> " + legacy.id() + ":" + legacy.data());
+                            return legacy;
                         })
                         .orElseGet(() -> {
                             // Report the error
                             converter.logMissingMapping(Converter.MissingMappingType.BLOCK, String.valueOf(chunkerBlockIdentifier));
 
                             // Return air
-                            return new LegacyIdentifier(0, (byte) 0);
+                            LegacyIdentifier legacy = new LegacyIdentifier(0, (byte) 0);
+                            converter.logDebug("writeLegacyBlockIdentifier " + chunkerBlockIdentifier + " -> " + legacy.id() + ":" + legacy.data());
+                            return legacy;
                         });
             }
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/JavaResolversBuilder.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/JavaResolversBuilder.java
@@ -271,7 +271,6 @@ public class JavaResolversBuilder {
                                 id = resolved.get();
                             }
                             LegacyIdentifier legacy = new LegacyIdentifier(id, (byte) identifier.getDataValue().orElse(0));
-                            converter.logDebug("writeLegacyBlockIdentifier " + chunkerBlockIdentifier + " -> " + legacy.id() + ":" + legacy.data());
                             return legacy;
                         })
                         .orElseGet(() -> {
@@ -279,9 +278,7 @@ public class JavaResolversBuilder {
                             converter.logMissingMapping(Converter.MissingMappingType.BLOCK, String.valueOf(chunkerBlockIdentifier));
 
                             // Return air
-                            LegacyIdentifier legacy = new LegacyIdentifier(0, (byte) 0);
-                            converter.logDebug("writeLegacyBlockIdentifier " + chunkerBlockIdentifier + " -> " + legacy.id() + ":" + legacy.data());
-                            return legacy;
+                            return new LegacyIdentifier(0, (byte) 0);
                         });
             }
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIdentifierResolver.java
@@ -5,6 +5,7 @@ import com.hivemc.chunker.conversion.encoding.base.Converter;
 import com.hivemc.chunker.conversion.encoding.base.Version;
 import com.hivemc.chunker.conversion.encoding.base.resolver.identifier.BlockMapping;
 import com.hivemc.chunker.conversion.encoding.base.resolver.identifier.ChunkerBlockIdentifierResolver;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.ChunkerBlockIdentifier;
 import com.hivemc.chunker.conversion.encoding.base.resolver.identifier.state.StateMappingGroup;
 import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.ChunkerBlockType;
 import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.ChunkerVanillaBlockType;
@@ -12,6 +13,10 @@ import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.b
 import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.VanillaBlockStates;
 import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.types.*;
 import it.unimi.dsi.fastutil.Pair;
+import com.hivemc.chunker.mapping.identifier.Identifier;
+
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import java.util.List;
 import java.util.Map;
@@ -44,6 +49,19 @@ public class JavaLegacyBlockIdentifierResolver extends ChunkerBlockIdentifierRes
         if (version.isLessThan(1, 8, 0)) {
             legacySimpleResolver = new JavaLegacyBlockIdentifierResolver(converter, new Version(1, 12, 2), reader, customIdentifiersAllowed);
         }
+    }
+
+    /**
+     * Resolve the numeric metadata value for the supplied block using the
+     * legacy state mappings. This can be used to fetch the data value that
+     * would be written when targeting Java 1.12.
+     *
+     * @param block the block identifier to resolve.
+     * @return the legacy data value if available.
+     */
+    public OptionalInt resolveLegacyData(ChunkerBlockIdentifier block) {
+        Optional<Identifier> out = resolveFrom(block);
+        return out.isPresent() ? out.get().getDataValue() : OptionalInt.empty();
     }
 
     @Override

--- a/cli/src/main/java/com/hivemc/chunker/mapping/LevelConvertMappings.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/LevelConvertMappings.java
@@ -34,6 +34,15 @@ public final class LevelConvertMappings {
     }
 
     /**
+     * Get the number of legacy ID mappings loaded.
+     *
+     * @return the count of mappings.
+     */
+    public static int size() {
+        return LEGACY_IDS.size();
+    }
+
+    /**
      * Get the numeric ID for a namespaced identifier.
      *
      * @param identifier the identifier to resolve.

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -375,6 +375,45 @@ public class JavaLegacySimpleMappingsTest {
     }
 
     @Test
+    public void testLevelConvertOverridesDefaultData() throws Exception {
+        // Build minimal level.dat mapping etfuturum:end_rod -> 198
+        CompoundTag root = new CompoundTag();
+        CompoundTag fml = new CompoundTag();
+        root.put("FML", fml);
+        CompoundTag itemData = new CompoundTag();
+        fml.put("ItemData", itemData);
+        itemData.put("etfuturum:end_rod", new IntTag(198));
+
+        File levelDat = File.createTempFile("level", ".dat");
+        levelDat.deleteOnExit();
+        Tag.writeGZipJavaNBT(levelDat, root);
+
+        File mapping = File.createTempFile("mapping", ".txt");
+        mapping.deleteOnExit();
+        Files.writeString(mapping.toPath(), "minecraft:end_rod -> etfuturum:end_rod[data=0]\n");
+
+        LevelConvertMappings.load(levelDat);
+        MappingsFile mappings = SimpleMappingsParser.parse(mapping.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 7, 10), false, false);
+
+        ChunkerBlockIdentifier input = new ChunkerBlockIdentifier(
+                ChunkerVanillaBlockType.END_ROD,
+                Map.of(VanillaBlockStates.FACING_ALL, FacingDirection.WEST)
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("198", result.get().getIdentifier());
+        assertEquals(4, ((StateValueInt) result.get().getStates().get("data")).getValue());
+    }
+
+    @Test
     public void testWriteLegacyIdentifierWithLevelConvert() throws Exception {
         // Build minimal level.dat mapping uptodate:glazed_terracotta_lime -> 1100
         CompoundTag root = new CompoundTag();


### PR DESCRIPTION
## Summary
- preserve state when levelConvert outputs numeric IDs
- add regression test for writing numeric IDs

## Testing
- `./gradlew test --tests "*LegacySimpleMappingsTest"`

------
https://chatgpt.com/codex/tasks/task_e_6880027156d48323a6684d435ffbf2a3