### PR TITLE
Add state group metadata resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following parameters are required:
 Additionally, the following parameters are supported:
 
 - `-m` / `--blockMappings` - a path to a json file or a json object containing block mappings.
-- `-sm` / `--simpleBlockMappings` - a path to a text file containing simple mappings in the form `old[state=value] -> new[state=value]`. State values are case sensitive; enumerated values such as directions should be written in upper case (e.g. `facing=WEST`). When provided alongside `--blockMappings` the entries are appended to the JSON mappings.
+- `-sm` / `--simpleBlockMappings` - a path to a text file containing simple mappings in the form `old[state=value] -> new[state=value] -> state_list`. The final section is optional and specifies a Java legacy state type such as `FENCE_GATE`. When a legacy type is supplied the converter automatically resolves the appropriate metadata (e.g. orientation) for the output. State values are case sensitive; enumerated values such as directions should be written in upper case (e.g. `facing=WEST`). When provided alongside `--blockMappings` the entries are appended to the JSON mappings.
 - `--levelConvert` - when used with `--simpleBlockMappings` resolves the output identifiers using a provided legacy `level.dat` file. When the level contains numeric IDs these are written directly, preserving metadata. Only supported when the destination format is Java 1.12 or lower.
 - `--generateSimpleMappingsTemplate` - write an example simple mapping file to the given path and exit.
 - `--convertMapping` - parse a simple mapping file (optionally with `--levelConvert`) and write `generated.json` next to the input file, then exit.

--- a/cli/src/main/java/com/hivemc/chunker/mapping/LegacyStateMetadataHelper.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/LegacyStateMetadataHelper.java
@@ -1,0 +1,130 @@
+package com.hivemc.chunker.mapping;
+
+import com.hivemc.chunker.conversion.encoding.base.resolver.identifier.state.StateMappingGroup;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.BlockState;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.BlockStateValue;
+import com.hivemc.chunker.conversion.intermediate.column.chunk.identifier.type.block.states.vanilla.VanillaBlockStates;
+import com.hivemc.chunker.conversion.encoding.java.base.resolver.identifier.legacy.JavaLegacyStateGroups;
+import com.hivemc.chunker.conversion.encoding.java.base.resolver.identifier.JavaStateGroups;
+import com.hivemc.chunker.mapping.identifier.states.StateValue;
+import com.hivemc.chunker.mapping.identifier.states.StateValueBoolean;
+import com.hivemc.chunker.mapping.identifier.states.StateValueInt;
+import com.hivemc.chunker.mapping.identifier.states.StateValueString;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helper used to resolve legacy metadata values by delegating to the existing
+ * {@link JavaLegacyStateGroups} and {@link VanillaBlockStates} definitions.
+ */
+public final class LegacyStateMetadataHelper {
+    private static final Map<String, StateMappingGroup> LEGACY_LOOKUP = new HashMap<>();
+    private static final Map<String, StateMappingGroup> JAVA_LOOKUP = new HashMap<>();
+
+    static {
+        try {
+            // Map legacy group names
+            for (Field field : JavaLegacyStateGroups.class.getFields()) {
+                if (Modifier.isStatic(field.getModifiers()) && field.getType() == StateMappingGroup.class) {
+                    LEGACY_LOOKUP.put(field.getName(), (StateMappingGroup) field.get(null));
+                }
+            }
+
+            // Map modern group names
+            for (Field field : JavaStateGroups.class.getFields()) {
+                if (Modifier.isStatic(field.getModifiers()) && StateMappingGroup.class.isAssignableFrom(field.getType())) {
+                    JAVA_LOOKUP.put(field.getName(), (StateMappingGroup) field.get(null));
+                }
+            }
+
+        } catch (IllegalAccessException ex) {
+            throw new ExceptionInInitializerError(ex);
+        }
+    }
+
+    private LegacyStateMetadataHelper() {
+    }
+
+    /**
+     * Resolve the legacy metadata value for a specific Java legacy state group
+     * using the supplied states.
+     *
+     * @param groupName the name of the legacy state group, e.g. "FENCE_GATE".
+     * @param states    map of state names to values (case-insensitive keys).
+     * @return the computed metadata value or {@code null} if it could not be
+     * resolved.
+     */
+    public static Integer resolve(String groupName, Map<String, StateValue<?>> states) {
+        StateMappingGroup legacy = LEGACY_LOOKUP.get(groupName);
+        if (legacy == null) return null;
+
+        // Normalise and unbox values
+        Map<String, Object> boxed = new Object2ObjectOpenHashMap<>(states.size());
+        for (Map.Entry<String, StateValue<?>> e : states.entrySet()) {
+            boxed.put(e.getKey().toLowerCase(), e.getValue().getBoxed());
+        }
+
+        Map<BlockState<?>, BlockStateValue> modern = new Object2ObjectOpenHashMap<>();
+        StateMappingGroup javaGroup = JAVA_LOOKUP.get(groupName);
+        if (javaGroup != null) {
+            javaGroup.applyInput((name, def) -> {
+                Object val = boxed.get(name.toLowerCase());
+                if (val instanceof String str) {
+                    val = str.toLowerCase();
+                } else if (val instanceof Boolean b) {
+                    val = b.toString();
+                }
+                return val;
+            }, modern);
+        }
+
+        Map<String, Object> outputs = new Object2ObjectOpenHashMap<>();
+        if (javaGroup != null) {
+            legacy.applyOutput((bs, def) -> {
+                BlockStateValue val = modern.get(bs);
+                if (val == null) {
+                    val = bs.getDefault();
+                }
+                return val;
+            }, outputs);
+        } else {
+            legacy.applyOutput((state, useDefault) -> {
+                StateValue<?> raw = states.get(state.getName().toLowerCase());
+                BlockStateValue val = parse(state, raw);
+                if (val == null && useDefault) return state.getDefault();
+                return val;
+            }, outputs);
+        }
+
+        Object data = outputs.get("data");
+        return data instanceof Integer ? (Integer) data : null;
+    }
+
+    private static BlockStateValue parse(BlockState<?> blockState, StateValue<?> value) {
+        Class<?> type = blockState.getValues()[0].getClass();
+        if (Enum.class.isAssignableFrom(type)) {
+            String strValue;
+            if (value instanceof StateValueBoolean b) {
+                strValue = b.getValue() ? "TRUE" : "FALSE";
+            } else if (value instanceof StateValueInt i) {
+                strValue = String.valueOf(i.getValue());
+            } else if (value instanceof StateValueString s) {
+                strValue = s.getValue();
+            } else {
+                return null;
+            }
+            try {
+                @SuppressWarnings("unchecked")
+                Enum<?> e = Enum.valueOf((Class<Enum>) type, strValue.toUpperCase());
+                return (BlockStateValue) e;
+            } catch (IllegalArgumentException ex) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/cli/src/main/java/com/hivemc/chunker/mapping/parser/SimpleMappingsTemplateGenerator.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/parser/SimpleMappingsTemplateGenerator.java
@@ -11,11 +11,15 @@ import java.nio.file.Path;
 public final class SimpleMappingsTemplateGenerator {
     private static final String TEMPLATE = """
 # Simple block mappings template
-# Format: old_identifier[state=value] -> new_identifier[state=value]
+# Format: old_identifier[state=value] -> new_identifier[state=value] -> state_list
 # Example mapping modern basalt to legacy ID 3005
 minecraft:basalt -> 3005
 # Example mapping with state and data value
 minecraft:oak_stairs[facing=EAST] -> 112:3
+# Example mapping applying a legacy state type
+minecraft:acacia_fence_gate -> etfuturum:acacia_fence_gate -> FENCE_GATE
+# Trapdoor using legacy metadata
+minecraft:acacia_trapdoor -> etfuturum:trapdoor_acacia -> TRAPDOOR
 """;
 
     private SimpleMappingsTemplateGenerator() {

--- a/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/mapping/SimpleMappingsParserTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the {@link SimpleMappingsParser} utility.
@@ -118,9 +119,9 @@ public class SimpleMappingsParserTest {
                 "waterlogged", StateValueBoolean.FALSE
         ));
         Identifier expected = new Identifier("3006", Map.of(
-                "FACING", new StateValueString("north"),
-                "Half", new StateValueString("top"),
-                "Open", StateValueBoolean.FALSE,
+                "facing", new StateValueString("north"),
+                "half", new StateValueString("top"),
+                "open", StateValueBoolean.FALSE,
                 "powered", StateValueBoolean.FALSE,
                 "waterlogged", StateValueBoolean.FALSE,
                 "data", new StateValueInt(2)
@@ -145,6 +146,188 @@ public class SimpleMappingsParserTest {
                 "open", new StateValueString("false"),
                 "powered", StateValueBoolean.FALSE,
                 "data", new StateValueInt(0)
+        ));
+
+        assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
+    }
+
+    @Test
+    public void testParseWithStateList() throws Exception {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:acacia_fence_gate -> etfuturum:acacia_fence_gate -> FENCE_GATE\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        String json = mappingsFile.toJsonString();
+        assertTrue(json.contains("\"state_list\": \"FENCE_GATE\""));
+    }
+
+    @Test
+    public void testFenceGateLegacyData() throws Exception {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:acacia_fence_gate -> 3000 -> FENCE_GATE\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:acacia_fence_gate", Map.of(
+                "facing", new StateValueString("WEST"),
+                "open", StateValueBoolean.TRUE,
+                "powered", StateValueBoolean.FALSE
+        ));
+        Identifier out = mappingsFile.convertBlock(input).orElse(null);
+        assertEquals(new Identifier("3000", Map.of(
+                "data", new StateValueInt(5)
+        )), out);
+    }
+
+    @Test
+    public void testTrapdoorLegacyData() throws Exception {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:acacia_trapdoor -> 3006 -> TRAPDOOR\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:acacia_trapdoor", Map.of(
+                "facing", new StateValueString("EAST"),
+                "half", new StateValueString("TOP"),
+                "open", StateValueBoolean.TRUE
+        ));
+        Identifier out = mappingsFile.convertBlock(input).orElse(null);
+        assertEquals(new Identifier("3006", Map.of(
+                "data", new StateValueInt(15)
+        )), out);
+    }
+
+    @Test
+    public void testDoorLegacyData() throws Exception {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:oak_door -> 3001 -> DOOR\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:oak_door", Map.of(
+                "hinge", new StateValueString("RIGHT"),
+                "half", new StateValueString("BOTTOM"),
+                "powered", StateValueBoolean.FALSE,
+                "facing", new StateValueString("EAST"),
+                "open", StateValueBoolean.FALSE
+        ));
+        Identifier out = mappingsFile.convertBlock(input).orElse(null);
+        assertEquals(new Identifier("3001", Map.of(
+                "data", new StateValueInt(0)
+        )), out);
+    }
+
+    @Test
+    public void testDoor2LegacyData() throws Exception {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:birch_door -> 3002 -> DOOR_2\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:birch_door", Map.of(
+                "hinge", new StateValueString("RIGHT"),
+                "half", new StateValueString("BOTTOM"),
+                "powered", StateValueBoolean.FALSE,
+                "facing", new StateValueString("EAST"),
+                "open", StateValueBoolean.FALSE
+        ));
+        Identifier out = mappingsFile.convertBlock(input).orElse(null);
+        assertEquals(new Identifier("3002", Map.of(
+                "data", new StateValueInt(0)
+        )), out);
+    }
+
+    @Test
+    public void testSlabHalfLegacyData() throws Exception {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:oak_slab -> 3003 -> SLAB_HALF\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:oak_slab", Map.of(
+                "type", new StateValueString("TOP")
+        ));
+        Identifier out = mappingsFile.convertBlock(input).orElse(null);
+        assertEquals(new Identifier("3003", Map.of(
+                "data", new StateValueInt(8)
+        )), out);
+    }
+
+    @Test
+    public void testButtonLegacyData() throws Exception {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:stone_button -> 3004 -> BUTTON\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:stone_button", Map.of(
+                "face", new StateValueString("WALL"),
+                "powered", StateValueBoolean.TRUE,
+                "facing", new StateValueString("EAST")
+        ));
+        Identifier out = mappingsFile.convertBlock(input).orElse(null);
+        assertEquals(new Identifier("3004", Map.of(
+                "data", new StateValueInt(9)
+        )), out);
+    }
+
+    @Test
+    public void testWarpedDoorLegacyData() throws Exception {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:warped_door -> netherlicious:doorwarped -> DOOR\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+
+        Object[][] cases = {
+                {"EAST", "LOWER", false, "LEFT", 0},
+                {"SOUTH", "LOWER", false, "LEFT", 1},
+                {"WEST", "LOWER", false, "LEFT", 2},
+                {"NORTH", "LOWER", false, "LEFT", 3},
+                {"EAST", "LOWER", true, "LEFT", 4},
+                {"SOUTH", "LOWER", true, "LEFT", 5},
+                {"WEST", "LOWER", true, "LEFT", 6},
+                {"NORTH", "LOWER", true, "LEFT", 7},
+                {"EAST", "LOWER", false, "RIGHT", 0},
+                {"SOUTH", "LOWER", false, "RIGHT", 1},
+        };
+
+        for (Object[] c : cases) {
+            Identifier input = new Identifier("minecraft:warped_door", Map.of(
+                    "facing", new StateValueString((String) c[0]),
+                    "half", new StateValueString((String) c[1]),
+                    "open", ((Boolean) c[2]) ? StateValueBoolean.TRUE : StateValueBoolean.FALSE,
+                    "hinge", new StateValueString((String) c[3])
+            ));
+            Identifier expected = new Identifier("netherlicious:doorwarped", Map.of(
+                    "data", new StateValueInt((Integer) c[4])
+            ));
+            assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));
+        }
+    }
+
+    @Test
+    public void testDataOverride() throws Exception {
+        File temp = File.createTempFile("simple", ".txt");
+        temp.deleteOnExit();
+        Files.writeString(temp.toPath(),
+                "minecraft:birch_wood -> uptodate:wood[data=2]\n");
+
+        MappingsFile mappingsFile = SimpleMappingsParser.parse(temp.toPath());
+        Identifier input = new Identifier("minecraft:birch_wood", Map.of(
+                "data", new StateValueInt(14)
+        ));
+        Identifier expected = new Identifier("uptodate:wood", Map.of(
+                "data", new StateValueInt(2)
         ));
 
         assertEquals(expected, mappingsFile.convertBlock(input).orElse(null));


### PR DESCRIPTION
## Summary
- calculate legacy metadata using `JavaLegacyStateGroups` and `JavaStateGroups`
- adjust simple mapping to compute data for legacy states
- add warped door metadata tests
- fix metadata helper to normalise input values and default missing states
- normalize state keys when applying simple mappings
- test manual data override for birch wood

## Testing
- `./gradlew test --no-daemon --console=plain --offline`

------
https://chatgpt.com/codex/tasks/task_e_6880b2ba22e883238818b118b49e44c0