### PR TITLE
Add prefix option to skip legacy level convert

### DIFF
--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -472,9 +472,18 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
     }
 
     private Optional<Identifier> applyLevelConvert(Optional<Identifier> output, ChunkerBlockIdentifier input) {
-        if (output.isEmpty() || !LevelConvertMappings.isLoaded()) return output;
+        if (output.isEmpty()) return output;
 
         Identifier id = output.get();
+
+        if (id.getStates().containsKey("meta:no_level_convert")) {
+            Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(id.getStates());
+            states.remove("meta:no_level_convert");
+            return Optional.of(new Identifier(id.getIdentifier(), states));
+        }
+
+        if (!LevelConvertMappings.isLoaded()) return output;
+
         String ident = id.getIdentifier();
 
         if (ident.startsWith("minecraft:")) {

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -352,29 +352,43 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
 
         // Apply legacy simple mappings to the output identifier when no preserved mapping is set
         if (input.getPreservedIdentifier() == null && mappingsFileResolvers != null && converter.shouldUseLegacySimpleMappings()) {
-            Optional<Identifier> base = output.isPresent() ? output : legacyResolveFrom(input);
-            if (base.isEmpty()) {
-                // Fall back to using the raw custom identifier when no legacy mapping exists
-                base = handleFallback(input);
-            }
-            if (base.isPresent()) {
-                Identifier lookup = base.get();
-                // When we resolved a direct output, try to lookup using the legacy identifier
-                if (output.isPresent()) {
-                    Optional<Identifier> legacy = legacyResolveFrom(input);
-                    if (legacy.isPresent()) {
-                        lookup = new Identifier(legacy.get().getIdentifier(), lookup.getStates());
-                    }
+            boolean mappedDirect = false;
+            if (output.isPresent()) {
+                Identifier direct = output.get();
+                Optional<Identifier> directMapped = mappingsFileResolvers.getMappings().convertBlock(direct);
+                if (directMapped.isPresent() && directMapped.get().getStates().containsKey("meta:no_level_convert")) {
+                    Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(directMapped.get().getStates());
+                    states.putAll(direct.getStates());
+                    output = Optional.of(new Identifier(directMapped.get().getIdentifier(), states));
+                    mappedDirect = true;
                 }
+            }
 
-                Optional<Identifier> mapped = mappingsFileResolvers.getMappings().convertBlock(lookup);
-                if (mapped.isPresent()) {
-                    Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(mapped.get().getStates());
-                    // Force any states from the flattened output onto the mapping
-                    // so legacy metadata such as orientation is always preserved.
-                    states.putAll(base.get().getStates());
+            if (!mappedDirect) {
+                Optional<Identifier> base = output.isPresent() ? output : legacyResolveFrom(input);
+                if (base.isEmpty()) {
+                    // Fall back to using the raw custom identifier when no legacy mapping exists
+                    base = handleFallback(input);
+                }
+                if (base.isPresent()) {
+                    Identifier lookup = base.get();
+                    // When we resolved a direct output, try to lookup using the legacy identifier
+                    if (output.isPresent()) {
+                        Optional<Identifier> legacy = legacyResolveFrom(input);
+                        if (legacy.isPresent()) {
+                            lookup = new Identifier(legacy.get().getIdentifier(), lookup.getStates());
+                        }
+                    }
 
-                    output = Optional.of(new Identifier(mapped.get().getIdentifier(), states));
+                    Optional<Identifier> mapped = mappingsFileResolvers.getMappings().convertBlock(lookup);
+                    if (mapped.isPresent()) {
+                        Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(mapped.get().getStates());
+                        // Force any states from the flattened output onto the mapping
+                        // so legacy metadata such as orientation is always preserved.
+                        states.putAll(base.get().getStates());
+
+                        output = Optional.of(new Identifier(mapped.get().getIdentifier(), states));
+                    }
                 }
             }
         }

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -323,7 +323,14 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
         if (mappingsFileResolvers == null) return output; // No mappings
 
         // Convert the block (using the inverse mappings if it's the writer)
-        Optional<Identifier> mappedIdentifier = (reader ? mappingsFileResolvers.getMappings() : mappingsFileResolvers.getInverseMappings()).convertBlock(input);
+        Identifier sanitizedInput = input;
+        if (input.getStates().containsKey("meta:no_level_convert")) {
+            Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(input.getStates());
+            states.remove("meta:no_level_convert");
+            sanitizedInput = new Identifier(input.getIdentifier(), states);
+        }
+
+        Optional<Identifier> mappedIdentifier = (reader ? mappingsFileResolvers.getMappings() : mappingsFileResolvers.getInverseMappings()).convertBlock(sanitizedInput);
         if (mappedIdentifier.isEmpty()) return output; // No custom mapping for this block
 
         // Attach the preserved identifier (the custom mapping for the output)
@@ -406,7 +413,13 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
             result = applyLevelConvert(output, input);
         } else {
             // Convert the preserved identifier to the chunker format
-            Optional<ChunkerBlockIdentifier> preservedAsChunker = resolveTo(input.getPreservedIdentifier().identifier());
+            Identifier preservedId = input.getPreservedIdentifier().identifier();
+            if (preservedId.getStates().containsKey("meta:no_level_convert")) {
+                Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(preservedId.getStates());
+                states.remove("meta:no_level_convert");
+                preservedId = new Identifier(preservedId.getIdentifier(), states);
+            }
+            Optional<ChunkerBlockIdentifier> preservedAsChunker = resolveTo(preservedId);
             if (preservedAsChunker.isPresent()) {
                 Map<BlockState<?>, BlockStateValue> states = new Object2ObjectOpenHashMap<>(preservedAsChunker.get().getPresentStates());
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -323,14 +323,7 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
         if (mappingsFileResolvers == null) return output; // No mappings
 
         // Convert the block (using the inverse mappings if it's the writer)
-        Identifier sanitizedInput = input;
-        if (input.getStates().containsKey("meta:no_level_convert")) {
-            Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(input.getStates());
-            states.remove("meta:no_level_convert");
-            sanitizedInput = new Identifier(input.getIdentifier(), states);
-        }
-
-        Optional<Identifier> mappedIdentifier = (reader ? mappingsFileResolvers.getMappings() : mappingsFileResolvers.getInverseMappings()).convertBlock(sanitizedInput);
+        Optional<Identifier> mappedIdentifier = (reader ? mappingsFileResolvers.getMappings() : mappingsFileResolvers.getInverseMappings()).convertBlock(input);
         if (mappedIdentifier.isEmpty()) return output; // No custom mapping for this block
 
         // Attach the preserved identifier (the custom mapping for the output)
@@ -413,13 +406,7 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
             result = applyLevelConvert(output, input);
         } else {
             // Convert the preserved identifier to the chunker format
-            Identifier preservedId = input.getPreservedIdentifier().identifier();
-            if (preservedId.getStates().containsKey("meta:no_level_convert")) {
-                Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(preservedId.getStates());
-                states.remove("meta:no_level_convert");
-                preservedId = new Identifier(preservedId.getIdentifier(), states);
-            }
-            Optional<ChunkerBlockIdentifier> preservedAsChunker = resolveTo(preservedId);
+            Optional<ChunkerBlockIdentifier> preservedAsChunker = resolveTo(input.getPreservedIdentifier().identifier());
             if (preservedAsChunker.isPresent()) {
                 Map<BlockState<?>, BlockStateValue> states = new Object2ObjectOpenHashMap<>(preservedAsChunker.get().getPresentStates());
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerBlockIdentifierResolver.java
@@ -405,14 +405,8 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
         if (input.getPreservedIdentifier() == null || reader == input.getPreservedIdentifier().fromReader()) {
             result = applyLevelConvert(output, input);
         } else {
-            // Convert the preserved identifier to the chunker format, stripping any meta states
-            Identifier preservedIdentifier = input.getPreservedIdentifier().identifier();
-            if (preservedIdentifier.getStates().containsKey("meta:no_level_convert")) {
-                Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(preservedIdentifier.getStates());
-                states.remove("meta:no_level_convert");
-                preservedIdentifier = new Identifier(preservedIdentifier.getIdentifier(), states);
-            }
-            Optional<ChunkerBlockIdentifier> preservedAsChunker = resolveTo(preservedIdentifier);
+            // Convert the preserved identifier to the chunker format
+            Optional<ChunkerBlockIdentifier> preservedAsChunker = resolveTo(input.getPreservedIdentifier().identifier());
             if (preservedAsChunker.isPresent()) {
                 Map<BlockState<?>, BlockStateValue> states = new Object2ObjectOpenHashMap<>(preservedAsChunker.get().getPresentStates());
 
@@ -433,18 +427,18 @@ public abstract class ChunkerBlockIdentifierResolver implements Resolver<Identif
                     Map<String, StateValue<?>> newOutputStates = new Object2ObjectOpenHashMap<>(preservedConverted.get().getStates());
 
                     // Replace states with the original preserved
-                    newOutputStates.putAll(preservedIdentifier.getStates());
+                    newOutputStates.putAll(input.getPreservedIdentifier().identifier().getStates());
 
                     result = applyLevelConvert(Optional.of(new Identifier(
-                            preservedIdentifier.getIdentifier(),
+                            input.getPreservedIdentifier().identifier().getIdentifier(),
                             newOutputStates
                     )), input);
                 } else {
-                    result = applyLevelConvert(Optional.of(preservedIdentifier), input);
+                    result = applyLevelConvert(Optional.of(input.getPreservedIdentifier().identifier()), input);
                 }
             } else {
                 // Directly use the preserved identifier as it's not possible to merge any states
-                result = applyLevelConvert(Optional.of(preservedIdentifier), input);
+                result = applyLevelConvert(Optional.of(input.getPreservedIdentifier().identifier()), input);
             }
         }
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerItemIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerItemIdentifierResolver.java
@@ -269,14 +269,7 @@ public abstract class ChunkerItemIdentifierResolver implements Resolver<Identifi
         if (mappingsFileResolvers == null) return output; // No mappings
 
         // Convert the item (using the inverse mappings if it's the writer)
-        Identifier sanitizedInput = input;
-        if (input.getStates().containsKey("meta:no_level_convert")) {
-            Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(input.getStates());
-            states.remove("meta:no_level_convert");
-            sanitizedInput = new Identifier(input.getIdentifier(), states);
-        }
-
-        Optional<Identifier> mappedIdentifier = (reader ? mappingsFileResolvers.getMappings() : mappingsFileResolvers.getInverseMappings()).convertItem(sanitizedInput);
+        Optional<Identifier> mappedIdentifier = (reader ? mappingsFileResolvers.getMappings() : mappingsFileResolvers.getInverseMappings()).convertItem(input);
         if (mappedIdentifier.isEmpty()) return output; // No custom mapping for this block
 
         // Attach the preserved identifier (the custom mapping for the output)
@@ -304,13 +297,7 @@ public abstract class ChunkerItemIdentifierResolver implements Resolver<Identifi
             return applyLevelConvert(output);
 
         // Convert the preserved identifier to the chunker format
-        Identifier preservedId = input.getPreservedIdentifier().identifier();
-        if (preservedId.getStates().containsKey("meta:no_level_convert")) {
-            Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(preservedId.getStates());
-            states.remove("meta:no_level_convert");
-            preservedId = new Identifier(preservedId.getIdentifier(), states);
-        }
-        Optional<ChunkerItemStack> preservedAsChunker = resolveTo(preservedId);
+        Optional<ChunkerItemStack> preservedAsChunker = resolveTo(input.getPreservedIdentifier().identifier());
         if (preservedAsChunker.isPresent() && preservedAsChunker.get().getIdentifier() instanceof ChunkerBlockIdentifier blockIdentifier) {
             Map<BlockState<?>, BlockStateValue> states = new Object2ObjectOpenHashMap<>(blockIdentifier.getPresentStates());
 

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerItemIdentifierResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/base/resolver/identifier/ChunkerItemIdentifierResolver.java
@@ -414,9 +414,17 @@ public abstract class ChunkerItemIdentifierResolver implements Resolver<Identifi
     }
 
     private Optional<Identifier> applyLevelConvert(Optional<Identifier> output) {
-        if (output.isEmpty() || !LevelConvertMappings.isLoaded()) return output;
+        if (output.isEmpty()) return output;
 
         Identifier id = output.get();
+
+        if (id.getStates().containsKey("meta:no_level_convert")) {
+            Map<String, StateValue<?>> states = new Object2ObjectOpenHashMap<>(id.getStates());
+            states.remove("meta:no_level_convert");
+            return Optional.of(new Identifier(id.getIdentifier(), states));
+        }
+
+        if (!LevelConvertMappings.isLoaded()) return output;
         String ident = id.getIdentifier();
 
         if (ident.startsWith("minecraft:")) {

--- a/cli/src/main/java/com/hivemc/chunker/mapping/parser/SimpleMappingsParser.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/parser/SimpleMappingsParser.java
@@ -68,8 +68,12 @@ public final class SimpleMappingsParser {
             if (oldParsed.states != null) {
                 obj.add("old_state_values", oldParsed.states);
             }
-            if (newParsed.states != null) {
-                obj.add("new_state_values", newParsed.states);
+            if (newParsed.states != null || oldParsed.ignoreLegacy || newParsed.ignoreLegacy) {
+                JsonObject newStates = newParsed.states == null ? new JsonObject() : newParsed.states;
+                if (oldParsed.ignoreLegacy || newParsed.ignoreLegacy) {
+                    newStates.addProperty("meta:no_level_convert", true);
+                }
+                obj.add("new_state_values", newStates);
             }
             array.add(obj);
             index++;
@@ -84,6 +88,11 @@ public final class SimpleMappingsParser {
 
     private static ParsedIdentifier parseIdentifier(String input) throws IOException {
         String trimmed = input.trim();
+        boolean ignoreLegacy = false;
+        if (trimmed.startsWith("=")) {
+            ignoreLegacy = true;
+            trimmed = trimmed.substring(1).trim();
+        }
         String identifierPart = trimmed;
         String statePart = null;
 
@@ -121,7 +130,7 @@ public final class SimpleMappingsParser {
             statesObj.add("data", new JsonPrimitive(Integer.parseInt(matcher.group(2))));
         }
 
-        return new ParsedIdentifier(identifier, statesObj);
+        return new ParsedIdentifier(identifier, statesObj, ignoreLegacy);
     }
 
     private static JsonPrimitive parseValue(String value) {
@@ -135,6 +144,6 @@ public final class SimpleMappingsParser {
         return new JsonPrimitive(value.toUpperCase());
     }
 
-    private record ParsedIdentifier(String identifier, JsonObject states) {
+    private record ParsedIdentifier(String identifier, JsonObject states, boolean ignoreLegacy) {
     }
 }

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -527,7 +527,7 @@ public class JavaLegacySimpleMappingsTest {
 
         Optional<Identifier> result = resolver.from(input);
         assertTrue(result.isPresent());
-        assertEquals("1299", result.get().getIdentifier());
+        assertEquals("1300", result.get().getIdentifier());
     }
 }
 

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacySimpleMappingsTest.java
@@ -529,5 +529,43 @@ public class JavaLegacySimpleMappingsTest {
         assertTrue(result.isPresent());
         assertEquals("1300", result.get().getIdentifier());
     }
+
+    @Test
+    public void testEqualsPrefixSkippedWhenLegacyIdExists() throws Exception {
+        CompoundTag root = new CompoundTag();
+        CompoundTag fml = new CompoundTag();
+        root.put("FML", fml);
+        CompoundTag itemData = new CompoundTag();
+        fml.put("ItemData", itemData);
+        itemData.put("custommod:block2", new IntTag(1300));
+        itemData.put("custommod:block", new IntTag(1299));
+
+        File levelDat = File.createTempFile("level", ".dat");
+        levelDat.deleteOnExit();
+        Tag.writeGZipJavaNBT(levelDat, root);
+
+        File mapping = File.createTempFile("mapping", ".txt");
+        mapping.deleteOnExit();
+        Files.writeString(mapping.toPath(), "=custommod:block -> custommod:block2\n");
+
+        LevelConvertMappings.load(levelDat);
+        MappingsFile mappings = SimpleMappingsParser.parse(mapping.toPath());
+
+        MockConverter converter = new MockConverter(null);
+        converter.setBlockMappings(new MappingsFileResolvers(mappings));
+        converter.setLegacySimpleMappings(true);
+
+        JavaLegacyBlockIdentifierResolver resolver = new JavaLegacyBlockIdentifierResolver(
+                converter, new Version(1, 7, 10), false, true);
+
+        ChunkerBlockIdentifier input = ChunkerBlockIdentifier.custom(
+                "custommod:block",
+                Map.of("facing", "EAST")
+        );
+
+        Optional<Identifier> result = resolver.from(input);
+        assertTrue(result.isPresent());
+        assertEquals("1299", result.get().getIdentifier());
+    }
 }
 


### PR DESCRIPTION
## Summary
- allow `=` prefix in simple mapping lines to skip legacy ID resolution
- support the meta state in identifier resolvers
- cover new behaviour with unit test

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6882b5f40f248323b81d1cf4984e2391