### PR TITLE
Fix level mapping with modded IDs

### DIFF
--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIDResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIDResolver.java
@@ -298,7 +298,11 @@ public class JavaLegacyBlockIDResolver implements Resolver<Integer, String> {
 
     @Override
     public Optional<String> to(Integer input) {
-        return Optional.ofNullable(mapping.inverse().get(input));
+        String result = mapping.inverse().get(input);
+        if (result == null && com.hivemc.chunker.mapping.LevelConvertMappings.isLoaded()) {
+            result = com.hivemc.chunker.mapping.LevelConvertMappings.getLegacyIdentifier(input);
+        }
+        return Optional.ofNullable(result);
     }
 
     @Override

--- a/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIDResolver.java
+++ b/cli/src/main/java/com/hivemc/chunker/conversion/encoding/java/base/resolver/identifier/legacy/JavaLegacyBlockIDResolver.java
@@ -294,6 +294,14 @@ public class JavaLegacyBlockIDResolver implements Resolver<Integer, String> {
             mapping.put("minecraft:concrete", 251);
             mapping.put("minecraft:concrete_powder", 252);
         }
+
+        // If legacy level.dat mappings are loaded, merge them so reverse lookups work
+        if (com.hivemc.chunker.mapping.LevelConvertMappings.isLoaded()) {
+            for (var entry : com.hivemc.chunker.mapping.LevelConvertMappings.getLegacyIds().entrySet()) {
+                mapping.forward().putIfAbsent(entry.getKey(), entry.getValue());
+                mapping.inverse().putIfAbsent(entry.getValue(), entry.getKey());
+            }
+        }
     }
 
     @Override

--- a/cli/src/main/java/com/hivemc/chunker/mapping/LevelConvertMappings.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/LevelConvertMappings.java
@@ -16,6 +16,7 @@ import java.util.Map;
  */
 public final class LevelConvertMappings {
     private static final Map<String, Integer> LEGACY_IDS = new HashMap<>();
+    private static final Map<Integer, String> LEGACY_IDENTIFIERS = new HashMap<>();
 
     private LevelConvertMappings() {
     }
@@ -28,8 +29,13 @@ public final class LevelConvertMappings {
      */
     public static void load(File levelDat) throws IOException {
         LEGACY_IDS.clear();
+        LEGACY_IDENTIFIERS.clear();
         if (levelDat != null) {
-            LEGACY_IDS.putAll(readLegacyIDs(levelDat));
+            Map<String, Integer> loaded = readLegacyIDs(levelDat);
+            LEGACY_IDS.putAll(loaded);
+            for (Map.Entry<String, Integer> e : loaded.entrySet()) {
+                LEGACY_IDENTIFIERS.put(e.getValue(), e.getKey());
+            }
         }
     }
 
@@ -59,6 +65,16 @@ public final class LevelConvertMappings {
      */
     public static boolean isLoaded() {
         return !LEGACY_IDS.isEmpty();
+    }
+
+    /**
+     * Get the namespaced identifier for a numeric ID.
+     *
+     * @param id the numeric ID.
+     * @return the identifier or null if not present.
+     */
+    public static String getLegacyIdentifier(int id) {
+        return LEGACY_IDENTIFIERS.get(id);
     }
 
     private static Map<String, Integer> readLegacyIDs(File levelDat) throws IOException {

--- a/cli/src/main/java/com/hivemc/chunker/mapping/LevelConvertMappings.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/LevelConvertMappings.java
@@ -68,6 +68,15 @@ public final class LevelConvertMappings {
     }
 
     /**
+     * Get an unmodifiable view of the identifier to numeric ID mappings.
+     *
+     * @return the loaded legacy ID map.
+     */
+    public static Map<String, Integer> getLegacyIds() {
+        return java.util.Collections.unmodifiableMap(LEGACY_IDS);
+    }
+
+    /**
      * Get the namespaced identifier for a numeric ID.
      *
      * @param id the numeric ID.

--- a/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacyBlockIDResolverLevelConvertTest.java
+++ b/cli/src/test/java/com/hivemc/chunker/conversion/java/resolver/legacy/JavaLegacyBlockIDResolverLevelConvertTest.java
@@ -1,0 +1,38 @@
+package com.hivemc.chunker.conversion.java.resolver.legacy;
+
+import com.hivemc.chunker.conversion.encoding.base.Version;
+import com.hivemc.chunker.conversion.encoding.java.base.resolver.identifier.legacy.JavaLegacyBlockIDResolver;
+import com.hivemc.chunker.mapping.LevelConvertMappings;
+import com.hivemc.chunker.nbt.tags.Tag;
+import com.hivemc.chunker.nbt.tags.collection.CompoundTag;
+import com.hivemc.chunker.nbt.tags.primitive.IntTag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JavaLegacyBlockIDResolverLevelConvertTest {
+    @Test
+    public void testReverseLookupWithLevelConvert() throws Exception {
+        CompoundTag root = new CompoundTag();
+        CompoundTag fml = new CompoundTag();
+        root.put("FML", fml);
+        CompoundTag itemData = new CompoundTag();
+        fml.put("ItemData", itemData);
+        itemData.put("custommod:block", new IntTag(1300));
+
+        File levelDat = File.createTempFile("level", ".dat");
+        levelDat.deleteOnExit();
+        Tag.writeGZipJavaNBT(levelDat, root);
+
+        LevelConvertMappings.load(levelDat);
+
+        JavaLegacyBlockIDResolver resolver = new JavaLegacyBlockIDResolver(new Version(1, 7, 10));
+        Optional<String> result = resolver.to(1300);
+        assertTrue(result.isPresent());
+        assertEquals("custommod:block", result.get());
+    }
+}


### PR DESCRIPTION
## Summary
- support reverse lookup of legacy IDs from level.dat
- check LevelConvert mappings when converting legacy IDs
- add regression test for legacy ID reverse lookup

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68897709edd083239495fa41e5d84ad8