### PR TITLE
Ensure legacy state groups include versioned mappings

### DIFF
--- a/cli/src/main/java/com/hivemc/chunker/mapping/LegacyStateMetadataHelper.java
+++ b/cli/src/main/java/com/hivemc/chunker/mapping/LegacyStateMetadataHelper.java
@@ -29,7 +29,7 @@ public final class LegacyStateMetadataHelper {
         try {
             // Map legacy group names
             for (Field field : JavaLegacyStateGroups.class.getFields()) {
-                if (Modifier.isStatic(field.getModifiers()) && field.getType() == StateMappingGroup.class) {
+                if (Modifier.isStatic(field.getModifiers()) && StateMappingGroup.class.isAssignableFrom(field.getType())) {
                     LEGACY_LOOKUP.put(field.getName(), (StateMappingGroup) field.get(null));
                 }
             }


### PR DESCRIPTION
## Summary
- include versioned state mapping groups when preparing legacy metadata lookup

## Testing
- ./gradlew :cli:test --tests "com.hivemc.chunker.mapping.LegacyStateMetadataHelperTest" *(fails: missing Java 17 toolchain)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c0f97cee48323bb7785f88883080d)