### PR TITLE
Add simple mapping support to schematic conversions

### DIFF
--- a/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
+++ b/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
@@ -63,7 +63,7 @@ public class CLI implements Runnable {
 
     @CommandLine.Option(
             names = {"--inputSchematic", "--input-schem"},
-            description = "Path to a .schematic or .schem file to convert."
+            description = "Directory containing .schematic/.schem files to convert."
     )
     private File inputSchematic;
 
@@ -82,7 +82,7 @@ public class CLI implements Runnable {
 
     @CommandLine.Option(
             names = {"--outputSchematic", "--output-schem"},
-            description = "Path to write the converted .schematic file to."
+            description = "Directory to write converted .schematic files to."
     )
     private File outputSchematic;
 
@@ -265,6 +265,16 @@ public class CLI implements Runnable {
                     return;
                 }
 
+                if (!inputSchematic.isDirectory()) {
+                    System.err.println("--inputSchematic must point to a directory containing schematics.");
+                    return;
+                }
+
+                if (outputSchematic.exists() && !outputSchematic.isDirectory()) {
+                    System.err.println("--outputSchematic must point to a directory for converted schematics.");
+                    return;
+                }
+
                 if (format != null && !format.equalsIgnoreCase("JAVA_1_7_10")) {
                     System.err.println("Schematic conversion only supports JAVA_1_7_10 outputs.");
                     return;
@@ -308,8 +318,8 @@ public class CLI implements Runnable {
                     }
 
                     boolean useLegacySimpleMappings = legacySimpleMappings || simpleMappingsProvided;
-                    SchematicConverter.convert(inputSchematic, outputSchematic, enableNEIDs, loadedMappings, useLegacySimpleMappings);
-                    System.out.println("Converted schematic written to " + outputSchematic.getAbsolutePath());
+                    int convertedCount = SchematicConverter.convertDirectory(inputSchematic.toPath(), outputSchematic.toPath(), enableNEIDs, loadedMappings, useLegacySimpleMappings);
+                    System.out.println("Converted " + convertedCount + " schematics into " + outputSchematic.getAbsolutePath());
                 } catch (Exception e) {
                     System.err.println("Failed to convert schematic: " + e.getMessage());
                     throw new RuntimeException(e);

--- a/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
+++ b/cli/src/main/java/com/hivemc/chunker/cli/CLI.java
@@ -19,6 +19,7 @@ import com.hivemc.chunker.mapping.LevelConvertMappings;
 import com.hivemc.chunker.mapping.parser.SimpleMappingsTemplateGenerator;
 import com.hivemc.chunker.pruning.PruningConfig;
 import com.hivemc.chunker.scheduling.task.TrackedTask;
+import com.hivemc.chunker.schematic.SchematicConverter;
 import com.google.gson.JsonArray;
 import java.io.IOException;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
@@ -56,14 +57,18 @@ public class CLI implements Runnable {
 
     @CommandLine.Option(
             names = {"--inputDirectory", "-i"},
-            required = true,
             description = "Directory to read the world from."
     )
     private File inputDirectory;
 
     @CommandLine.Option(
+            names = {"--inputSchematic", "--input-schem"},
+            description = "Path to a .schematic or .schem file to convert."
+    )
+    private File inputSchematic;
+
+    @CommandLine.Option(
             names = {"--outputFormat", "-f"},
-            required = true,
             description = "The format to convert the world to.",
             converter = EncodingTypeValidator.class
     )
@@ -71,10 +76,15 @@ public class CLI implements Runnable {
 
     @CommandLine.Option(
             names = {"--outputDirectory", "-o"},
-            required = true,
             description = "Directory to write the world to."
     )
     private File outputDirectory;
+
+    @CommandLine.Option(
+            names = {"--outputSchematic", "--output-schem"},
+            description = "Path to write the converted .schematic file to."
+    )
+    private File outputSchematic;
 
     @CommandLine.Option(
             names = {"--blockMappings", "-m"},
@@ -245,6 +255,70 @@ public class CLI implements Runnable {
                     System.err.println("Failed to generate mapping: " + e.getMessage());
                     throw new RuntimeException(e);
                 }
+                return;
+            }
+
+            boolean schematicMode = inputSchematic != null || outputSchematic != null;
+            if (schematicMode) {
+                if (inputSchematic == null || outputSchematic == null) {
+                    System.err.println("--inputSchematic and --outputSchematic must both be provided for schematic conversion.");
+                    return;
+                }
+
+                if (format != null && !format.equalsIgnoreCase("JAVA_1_7_10")) {
+                    System.err.println("Schematic conversion only supports JAVA_1_7_10 outputs.");
+                    return;
+                }
+
+                try {
+                    if (levelConvert != null) {
+                        LevelConvertMappings.load(levelConvert);
+                        if (debug) {
+                            System.out.println("[DEBUG] Loaded " + LevelConvertMappings.size() + " level.dat mappings");
+                        }
+                    }
+
+                    MappingsFile loadedMappings = null;
+                    if (blockMappings != null) {
+                        try {
+                            loadedMappings = MappingsFile.load(blockMappings.getJSONObjectString());
+                        } catch (Exception e) {
+                            System.err.println("Failed to parse block mappings.");
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    if (simpleBlockMappings != null) {
+                        try {
+                            MappingsFile mappingsFile = SimpleMappingsParser.parse(simpleBlockMappings.toPath());
+                            if (debug) {
+                                int count = mappingsFile.toJson().getAsJsonObject().getAsJsonArray("identifiers").size();
+                                System.out.println("[DEBUG] Parsed " + count + " simple mappings");
+                            }
+                            simpleMappingsProvided = true;
+                            if (loadedMappings == null) {
+                                loadedMappings = mappingsFile;
+                            } else {
+                                loadedMappings = mergeMappings(loadedMappings, mappingsFile);
+                            }
+                        } catch (Exception e) {
+                            System.err.println("Failed to parse simple block mappings.");
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    boolean useLegacySimpleMappings = legacySimpleMappings || simpleMappingsProvided;
+                    SchematicConverter.convert(inputSchematic, outputSchematic, enableNEIDs, loadedMappings, useLegacySimpleMappings);
+                    System.out.println("Converted schematic written to " + outputSchematic.getAbsolutePath());
+                } catch (Exception e) {
+                    System.err.println("Failed to convert schematic: " + e.getMessage());
+                    throw new RuntimeException(e);
+                }
+                return;
+            }
+
+            if (inputDirectory == null || outputDirectory == null || format == null) {
+                System.err.println("--inputDirectory, --outputDirectory and --outputFormat are required when not converting schematics.");
                 return;
             }
 

--- a/cli/src/main/java/com/hivemc/chunker/schematic/SchematicConverter.java
+++ b/cli/src/main/java/com/hivemc/chunker/schematic/SchematicConverter.java
@@ -5,6 +5,7 @@ import com.hivemc.chunker.mapping.MappingsFile;
 import com.hivemc.chunker.mapping.identifier.Identifier;
 import com.hivemc.chunker.nbt.TagType;
 import com.hivemc.chunker.nbt.io.Reader;
+import com.hivemc.chunker.nbt.io.Writer;
 import com.hivemc.chunker.nbt.tags.Tag;
 import com.hivemc.chunker.nbt.tags.collection.CompoundTag;
 import com.hivemc.chunker.nbt.tags.collection.ListTag;
@@ -14,8 +15,10 @@ import com.hivemc.chunker.nbt.tags.primitive.ShortTag;
 import com.hivemc.chunker.nbt.tags.primitive.StringTag;
 import com.hivemc.chunker.nbt.tags.TagWithName;
 
-import java.io.File;
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
 import java.io.DataInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -24,6 +27,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.OptionalInt;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * Minimal converter capable of reading Sponge .schem files or classic
@@ -31,6 +35,8 @@ import java.util.zip.GZIPInputStream;
  * format used by WorldEdit GTNH (1.7.10) with support for extended block IDs.
  */
 public final class SchematicConverter {
+    private static final String SCHEMATIC_ROOT_NAME = "Schematic";
+
     private SchematicConverter() {
     }
 
@@ -248,7 +254,17 @@ public final class SchematicConverter {
         }
 
         Files.createDirectories(output.getParent());
-        Tag.writeGZipJavaNBT(output.toFile(), root);
+        writeWithRootName(output, root);
+    }
+
+    private static void writeWithRootName(Path output, CompoundTag root) throws IOException {
+        try (var fileOutputStream = Files.newOutputStream(output);
+             var gzipOutputStream = new GZIPOutputStream(fileOutputStream);
+             var bufferedOutputStream = new BufferedOutputStream(gzipOutputStream);
+             var writerStream = new DataOutputStream(bufferedOutputStream)) {
+            Tag.encodeNamed(Writer.toJavaWriter(writerStream), SCHEMATIC_ROOT_NAME, root);
+            writerStream.flush();
+        }
     }
 
     private record PaletteMapping(int paletteIndex, int blockId, int meta) {

--- a/cli/src/main/java/com/hivemc/chunker/schematic/SchematicConverter.java
+++ b/cli/src/main/java/com/hivemc/chunker/schematic/SchematicConverter.java
@@ -1,5 +1,7 @@
 package com.hivemc.chunker.schematic;
 
+import com.hivemc.chunker.conversion.encoding.base.Version;
+import com.hivemc.chunker.conversion.encoding.java.base.resolver.identifier.legacy.JavaLegacyBlockIDResolver;
 import com.hivemc.chunker.mapping.LevelConvertMappings;
 import com.hivemc.chunker.mapping.MappingsFile;
 import com.hivemc.chunker.mapping.identifier.Identifier;
@@ -23,9 +25,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -36,6 +42,7 @@ import java.util.zip.GZIPOutputStream;
  */
 public final class SchematicConverter {
     private static final String SCHEMATIC_ROOT_NAME = "Schematic";
+    private static final JavaLegacyBlockIDResolver LEGACY_BLOCK_RESOLVER = new JavaLegacyBlockIDResolver(new Version(1, 12, 2));
 
     private SchematicConverter() {
     }
@@ -60,6 +67,50 @@ public final class SchematicConverter {
             data = applyMappings(data, mappingsFile, legacySimpleMappings);
         }
         writeClassic(output.toPath(), data, allowNeids);
+    }
+
+    /**
+     * Convert all schematics found under the input directory into the output
+     * directory, preserving relative paths and writing results with a
+     * <code>.schematic</code> extension.
+     *
+     * @param inputDirectory  root directory to scan for schematics
+     * @param outputDirectory directory to emit converted schematics into
+     * @param allowNeids      whether NEIDs encoding should be emitted when needed
+     * @param mappingsFile    optional mappings file used during conversion
+     * @param legacySimpleMappings whether legacy simple mappings are enabled
+     * @return number of schematics converted
+     * @throws IOException if reading or writing fails
+     */
+    public static int convertDirectory(Path inputDirectory, Path outputDirectory, boolean allowNeids, MappingsFile mappingsFile, boolean legacySimpleMappings) throws IOException {
+        Files.createDirectories(outputDirectory);
+
+        List<Path> schematics;
+        try (Stream<Path> paths = Files.walk(inputDirectory)) {
+            schematics = paths
+                    .filter(Files::isRegularFile)
+                    .filter(SchematicConverter::isSchematicFile)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+
+        int converted = 0;
+        for (Path input : schematics) {
+            Path relative = inputDirectory.relativize(input);
+            String fileName = relative.getFileName().toString();
+            String base = fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : fileName;
+            Path targetRelative = relative.resolveSibling(base + ".schematic");
+            Path output = outputDirectory.resolve(targetRelative);
+            Files.createDirectories(output.getParent());
+            convert(input.toFile(), output.toFile(), allowNeids, mappingsFile, legacySimpleMappings);
+            converted++;
+        }
+
+        return converted;
+    }
+
+    private static boolean isSchematicFile(Path path) {
+        String name = path.getFileName().toString().toLowerCase();
+        return name.endsWith(".schem") || name.endsWith(".schematic");
     }
 
     /**
@@ -156,7 +207,7 @@ public final class SchematicConverter {
     }
 
     private static int resolveLegacyId(String name) {
-        Integer id = LevelConvertMappings.getLegacyId(name);
+        Integer id = resolveLegacyBlockId(name);
         return id != null ? id : 0;
     }
 
@@ -179,18 +230,20 @@ public final class SchematicConverter {
         int[] meta = Arrays.copyOf(data.getBlockData(), data.getBlockData().length);
 
         for (int i = 0; i < ids.length; i++) {
-            String identifier = LevelConvertMappings.getLegacyIdentifier(ids[i]);
+            String identifier = resolveIdentifierFromMappings(ids[i]);
             if (identifier == null) {
                 continue;
             }
 
-            OptionalInt metaValue = legacySimpleMappings ? OptionalInt.of(meta[i]) : OptionalInt.empty();
+            final int index = i;
+            final int currentMeta = meta[i];
+            OptionalInt metaValue = legacySimpleMappings ? OptionalInt.of(currentMeta) : OptionalInt.empty();
             Identifier input = Identifier.fromData(identifier, metaValue);
             mappingsFile.convertBlock(input).ifPresent(converted -> {
-                Integer newId = LevelConvertMappings.getLegacyId(converted.getIdentifier());
+                Integer newId = resolveLegacyBlockId(converted.getIdentifier());
                 if (newId != null) {
-                    ids[i] = newId;
-                    meta[i] = converted.getDataValue().orElse(meta[i]);
+                    ids[index] = newId;
+                    meta[index] = converted.getDataValue().orElse(currentMeta);
                 }
             });
         }
@@ -276,5 +329,21 @@ public final class SchematicConverter {
                 }
             }
         }
+    }
+
+    private static Integer resolveLegacyBlockId(String identifier) {
+        Integer levelId = LevelConvertMappings.getLegacyId(identifier);
+        if (levelId != null) {
+            return levelId;
+        }
+        return LEGACY_BLOCK_RESOLVER.from(identifier).orElse(null);
+    }
+
+    private static String resolveIdentifierFromMappings(int id) {
+        String identifier = LevelConvertMappings.getLegacyIdentifier(id);
+        if (identifier != null) {
+            return identifier;
+        }
+        return LEGACY_BLOCK_RESOLVER.to(id).orElse(null);
     }
 }

--- a/cli/src/main/java/com/hivemc/chunker/schematic/SchematicConverter.java
+++ b/cli/src/main/java/com/hivemc/chunker/schematic/SchematicConverter.java
@@ -1,0 +1,264 @@
+package com.hivemc.chunker.schematic;
+
+import com.hivemc.chunker.mapping.LevelConvertMappings;
+import com.hivemc.chunker.mapping.MappingsFile;
+import com.hivemc.chunker.mapping.identifier.Identifier;
+import com.hivemc.chunker.nbt.TagType;
+import com.hivemc.chunker.nbt.io.Reader;
+import com.hivemc.chunker.nbt.tags.Tag;
+import com.hivemc.chunker.nbt.tags.collection.CompoundTag;
+import com.hivemc.chunker.nbt.tags.collection.ListTag;
+import com.hivemc.chunker.nbt.tags.array.ByteArrayTag;
+import com.hivemc.chunker.nbt.tags.primitive.IntTag;
+import com.hivemc.chunker.nbt.tags.primitive.ShortTag;
+import com.hivemc.chunker.nbt.tags.primitive.StringTag;
+import com.hivemc.chunker.nbt.tags.TagWithName;
+
+import java.io.File;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Minimal converter capable of reading Sponge .schem files or classic
+ * WorldEdit .schematic files and writing them back to the classic schematic
+ * format used by WorldEdit GTNH (1.7.10) with support for extended block IDs.
+ */
+public final class SchematicConverter {
+    private SchematicConverter() {
+    }
+
+    /**
+     * Convert the input schematic (classic or Sponge) into a classic
+     * WorldEdit schematic written to {@code output}.
+     *
+     * @param input      the input schematic file.
+     * @param output     the destination schematic file.
+     * @param allowNeids whether NotEnoughIDs encoding (AddBlocks2) should be
+     *                   emitted when blocks exceed 4095.
+     * @throws IOException if reading or writing fails.
+     */
+    public static void convert(File input, File output, boolean allowNeids) throws IOException {
+        convert(input, output, allowNeids, null, false);
+    }
+
+    public static void convert(File input, File output, boolean allowNeids, MappingsFile mappingsFile, boolean legacySimpleMappings) throws IOException {
+        SchematicData data = read(input.toPath());
+        if (mappingsFile != null) {
+            data = applyMappings(data, mappingsFile, legacySimpleMappings);
+        }
+        writeClassic(output.toPath(), data, allowNeids);
+    }
+
+    /**
+     * Read a schematic from either Sponge .schem or classic .schematic.
+     */
+    public static SchematicData read(Path path) throws IOException {
+        CompoundTag root = readRoot(path);
+        if (root == null) {
+            throw new IOException("Invalid schematic: no root tag present");
+        }
+
+        if (root.contains("Palette") && root.contains("BlockData")) {
+            return readSponge(root);
+        }
+        return readClassic(root);
+    }
+
+    private static SchematicData readClassic(CompoundTag root) throws IOException {
+        short width = root.getShort("Width", (short) -1);
+        short height = root.getShort("Height", (short) -1);
+        short length = root.getShort("Length", (short) -1);
+        if (width <= 0 || height <= 0 || length <= 0) {
+            throw new IOException("Invalid schematic dimensions");
+        }
+
+        byte[] blocks = root.getByteArray("Blocks");
+        byte[] blockData = root.getByteArray("Data");
+        if (blocks.length != blockData.length) {
+            throw new IOException("Mismatched block/data lengths");
+        }
+
+        byte[] addBlocks = root.contains("AddBlocks") ? root.getByteArray("AddBlocks") : null;
+        byte[] addBlocks2 = root.contains("AddBlocks2") ? root.getByteArray("AddBlocks2") : null;
+        byte[] addData = root.contains("AddData") ? root.getByteArray("AddData") : null;
+
+        int[] blockIds = new int[blocks.length];
+        int[] meta = new int[blocks.length];
+        for (int index = 0; index < blocks.length; index++) {
+            int id = blocks[index] & 0xFF;
+            if (addBlocks != null && (index >> 1) < addBlocks.length) {
+                int add = (index & 1) == 0 ? addBlocks[index >> 1] & 0x0F : (addBlocks[index >> 1] & 0xF0) >> 4;
+                id |= add << 8;
+            }
+            if (addBlocks2 != null && (index >> 1) < addBlocks2.length) {
+                int add = (index & 1) == 0 ? addBlocks2[index >> 1] & 0x0F : (addBlocks2[index >> 1] & 0xF0) >> 4;
+                id |= add << 12;
+            }
+
+            int data = blockData[index] & 0xFF;
+            if (addData != null && index < addData.length) {
+                data |= (addData[index] & 0xFF) << 8;
+            }
+            blockIds[index] = id;
+            meta[index] = data;
+        }
+
+        return new SchematicData(width, height, length, blockIds, meta);
+    }
+
+    private static CompoundTag readRoot(Path path) throws IOException {
+        try (InputStream input = Files.newInputStream(path);
+             GZIPInputStream gzip = new GZIPInputStream(input);
+             DataInputStream dataInputStream = new DataInputStream(gzip)) {
+            TagWithName<CompoundTag> pair = Tag.decodeNamed(Reader.toJavaReader(dataInputStream), CompoundTag.class);
+            return pair.tag();
+        }
+    }
+
+    private static SchematicData readSponge(CompoundTag root) throws IOException {
+        short width = root.getShort("Width", (short) -1);
+        short height = root.getShort("Height", (short) -1);
+        short length = root.getShort("Length", (short) -1);
+        if (width <= 0 || height <= 0 || length <= 0) {
+            throw new IOException("Invalid schematic dimensions");
+        }
+
+        CompoundTag paletteTag = root.getCompound("Palette");
+        byte[] blockData = root.getByteArray("BlockData");
+        int[] blockIds = new int[blockData.length];
+        int[] meta = new int[blockData.length];
+
+        for (Map.Entry<String, Tag<?>> entry : paletteTag.getValue().entrySet()) {
+            if (entry.getValue() instanceof IntTag indexTag) {
+                int index = indexTag.getValue();
+                if (index < 0) continue;
+                String name = entry.getKey();
+                int id = resolveLegacyId(name);
+                PaletteMapping mapping = new PaletteMapping(index, id, resolveMetaFromState(name));
+                mapping.apply(blockIds, meta, blockData);
+            }
+        }
+
+        return new SchematicData(width, height, length, blockIds, meta);
+    }
+
+    private static int resolveLegacyId(String name) {
+        Integer id = LevelConvertMappings.getLegacyId(name);
+        return id != null ? id : 0;
+    }
+
+    private static int resolveMetaFromState(String state) {
+        int bracket = state.indexOf('[');
+        if (bracket == -1) return 0;
+        // Simple heuristic: look for ":<meta>" suffix inside the state string (e.g. "minecraft:stone[type=1]")
+        int equals = state.lastIndexOf('=');
+        if (equals == -1) return 0;
+        try {
+            String value = state.substring(equals + 1, state.length() - 1);
+            return Integer.parseInt(value);
+        } catch (Exception ignored) {
+            return 0;
+        }
+    }
+
+    private static SchematicData applyMappings(SchematicData data, MappingsFile mappingsFile, boolean legacySimpleMappings) {
+        int[] ids = Arrays.copyOf(data.getBlockIds(), data.getBlockIds().length);
+        int[] meta = Arrays.copyOf(data.getBlockData(), data.getBlockData().length);
+
+        for (int i = 0; i < ids.length; i++) {
+            String identifier = LevelConvertMappings.getLegacyIdentifier(ids[i]);
+            if (identifier == null) {
+                continue;
+            }
+
+            OptionalInt metaValue = legacySimpleMappings ? OptionalInt.of(meta[i]) : OptionalInt.empty();
+            Identifier input = Identifier.fromData(identifier, metaValue);
+            mappingsFile.convertBlock(input).ifPresent(converted -> {
+                Integer newId = LevelConvertMappings.getLegacyId(converted.getIdentifier());
+                if (newId != null) {
+                    ids[i] = newId;
+                    meta[i] = converted.getDataValue().orElse(meta[i]);
+                }
+            });
+        }
+
+        return new SchematicData(data.getWidth(), data.getHeight(), data.getLength(), ids, meta);
+    }
+
+    /**
+     * Write the schematic to classic WorldEdit schematic format.
+     */
+    public static void writeClassic(Path output, SchematicData schematic, boolean allowNeids) throws IOException {
+        int volume = schematic.getBlockIds().length;
+        byte[] blocks = new byte[volume];
+        byte[] data = new byte[volume];
+        byte[] addBlocks = null;
+        byte[] addBlocks2 = null;
+        byte[] addData = null;
+
+        for (int i = 0; i < volume; i++) {
+            int id = schematic.getBlockIds()[i];
+            int meta = schematic.getBlockData()[i];
+            blocks[i] = (byte) (id & 0xFF);
+            if (id > 255) {
+                if (addBlocks == null) addBlocks = new byte[(volume >> 1) + 1];
+                addBlocks[i >> 1] = (byte) (((i & 1) == 0) ? addBlocks[i >> 1] & 0xF0 | (id >> 8) & 0xF
+                        : addBlocks[i >> 1] & 0xF | ((id >> 8) & 0xF) << 4);
+            }
+            if (allowNeids && id > 4095) {
+                if (addBlocks2 == null) addBlocks2 = new byte[(volume >> 1) + 1];
+                addBlocks2[i >> 1] = (byte) (((i & 1) == 0) ? addBlocks2[i >> 1] & 0xF0 | (id >> 12) & 0xF
+                        : addBlocks2[i >> 1] & 0xF | ((id >> 12) & 0xF) << 4);
+            }
+
+            data[i] = (byte) (meta & 0xFF);
+            if (meta > 15) {
+                if (addData == null) addData = new byte[volume];
+                addData[i] = (byte) ((meta >> 8) & 0xFF);
+            }
+        }
+
+        CompoundTag root = new CompoundTag();
+        root.put("Width", new ShortTag(schematic.getWidth()));
+        root.put("Height", new ShortTag(schematic.getHeight()));
+        root.put("Length", new ShortTag(schematic.getLength()));
+        root.put("Materials", new StringTag("Alpha"));
+        root.put("Blocks", new ByteArrayTag(blocks));
+        root.put("Data", new ByteArrayTag(data));
+        root.put("Entities", new ListTag<>(TagType.COMPOUND, Arrays.asList()));
+        root.put("TileEntities", new ListTag<>(TagType.COMPOUND, Arrays.asList()));
+
+        if (addBlocks != null) {
+            root.put("AddBlocks", new ByteArrayTag(addBlocks));
+        }
+
+        if (addBlocks2 != null) {
+            root.put("AddBlocks2", new ByteArrayTag(addBlocks2));
+        }
+
+        if (addData != null) {
+            root.put("AddData", new ByteArrayTag(addData));
+        }
+
+        Files.createDirectories(output.getParent());
+        Tag.writeGZipJavaNBT(output.toFile(), root);
+    }
+
+    private record PaletteMapping(int paletteIndex, int blockId, int meta) {
+        void apply(int[] ids, int[] data, byte[] paletteData) {
+            for (int i = 0; i < paletteData.length; i++) {
+                if ((paletteData[i] & 0xFF) == paletteIndex) {
+                    ids[i] = blockId;
+                    data[i] = meta;
+                }
+            }
+        }
+    }
+}

--- a/cli/src/main/java/com/hivemc/chunker/schematic/SchematicData.java
+++ b/cli/src/main/java/com/hivemc/chunker/schematic/SchematicData.java
@@ -4,7 +4,7 @@ package com.hivemc.chunker.schematic;
  * Represents the contents of a schematic file using legacy block IDs and data
  * values compatible with WorldEdit for Minecraft 1.7.10.
  */
-public class SchematicData {
+public final class SchematicData {
     private final short width;
     private final short height;
     private final short length;

--- a/cli/src/main/java/com/hivemc/chunker/schematic/SchematicData.java
+++ b/cli/src/main/java/com/hivemc/chunker/schematic/SchematicData.java
@@ -1,0 +1,41 @@
+package com.hivemc.chunker.schematic;
+
+/**
+ * Represents the contents of a schematic file using legacy block IDs and data
+ * values compatible with WorldEdit for Minecraft 1.7.10.
+ */
+public class SchematicData {
+    private final short width;
+    private final short height;
+    private final short length;
+    private final int[] blockIds;
+    private final int[] blockData;
+
+    public SchematicData(short width, short height, short length, int[] blockIds, int[] blockData) {
+        this.width = width;
+        this.height = height;
+        this.length = length;
+        this.blockIds = blockIds;
+        this.blockData = blockData;
+    }
+
+    public short getWidth() {
+        return width;
+    }
+
+    public short getHeight() {
+        return height;
+    }
+
+    public short getLength() {
+        return length;
+    }
+
+    public int[] getBlockIds() {
+        return blockIds;
+    }
+
+    public int[] getBlockData() {
+        return blockData;
+    }
+}

--- a/cli/src/test/java/com/hivemc/chunker/schematic/SchematicConverterTests.java
+++ b/cli/src/test/java/com/hivemc/chunker/schematic/SchematicConverterTests.java
@@ -8,6 +8,8 @@ import com.hivemc.chunker.nbt.tags.collection.CompoundTag;
 import com.hivemc.chunker.nbt.tags.array.ByteArrayTag;
 import com.hivemc.chunker.nbt.tags.primitive.IntTag;
 import com.hivemc.chunker.nbt.tags.primitive.ShortTag;
+import com.hivemc.chunker.nbt.tags.TagWithName;
+import com.hivemc.chunker.nbt.io.Reader;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -95,5 +97,21 @@ class SchematicConverterTests {
 
         SchematicData converted = SchematicConverter.read(output);
         assertEquals(2000, converted.getBlockIds()[0]);
+    }
+
+    @Test
+    void writesSchematicRootName() throws Exception {
+        Path output = Files.createTempFile("named", ".schematic");
+        SchematicData data = new SchematicData((short) 1, (short) 1, (short) 1, new int[]{1}, new int[]{0});
+
+        SchematicConverter.writeClassic(output, data, true);
+
+        try (var inputStream = Files.newInputStream(output);
+             var gzipInputStream = new java.util.zip.GZIPInputStream(inputStream);
+             var dataInputStream = new java.io.DataInputStream(gzipInputStream)) {
+            TagWithName<CompoundTag> decoded = Tag.decodeNamed(Reader.toJavaReader(dataInputStream), CompoundTag.class);
+            assertEquals("Schematic", decoded.name());
+            assertEquals(1, decoded.tag().getShort("Width", (short) -1));
+        }
     }
 }

--- a/cli/src/test/java/com/hivemc/chunker/schematic/SchematicConverterTests.java
+++ b/cli/src/test/java/com/hivemc/chunker/schematic/SchematicConverterTests.java
@@ -100,6 +100,70 @@ class SchematicConverterTests {
     }
 
     @Test
+    void appliesMappingsUsingLevelDatIdentifiers() throws Exception {
+        // Level.dat that supplies IDs for both source and target identifiers
+        CompoundTag level = new CompoundTag();
+        CompoundTag forge = new CompoundTag();
+        CompoundTag itemData = new CompoundTag();
+        itemData.put("minecraft:observer", new IntTag(5000));
+        itemData.put("etfuturum:observer", new IntTag(6000));
+        forge.put("ItemData", itemData);
+        level.put("FML", forge);
+
+        File levelDat = File.createTempFile("level", ".dat");
+        Tag.writeGZipJavaNBT(levelDat, level);
+        LevelConvertMappings.load(levelDat);
+
+        // Schematic that uses the legacy ID from level.dat
+        SchematicData data = new SchematicData((short) 1, (short) 1, (short) 1, new int[]{5000}, new int[]{5});
+        Path input = Files.createTempFile("legacy-level", ".schematic");
+        SchematicConverter.writeClassic(input, data, true);
+
+        // Simple mapping redirects to the alternate identifier backed by level.dat
+        Path mappingFile = Files.createTempFile("observer", ".txt");
+        Files.writeString(mappingFile, "minecraft:observer -> etfuturum:observer\n");
+        MappingsFile mappings = SimpleMappingsParser.parse(mappingFile);
+
+        Path output = Files.createTempFile("converted-level", ".schematic");
+        SchematicConverter.convert(input.toFile(), output.toFile(), true, mappings, true);
+
+        SchematicData converted = SchematicConverter.read(output);
+        assertEquals(6000, converted.getBlockIds()[0]);
+        assertEquals(5, converted.getBlockData()[0]);
+    }
+
+    @Test
+    void convertsDirectoriesOfSchematics() throws Exception {
+        Path inputDir = Files.createTempDirectory("schem-input");
+        Path nested = Files.createDirectories(inputDir.resolve("nested"));
+
+        // Write a Sponge schematic in a nested folder
+        CompoundTag palette = new CompoundTag();
+        palette.put("minecraft:stone", new IntTag(0));
+        CompoundTag spongeRoot = new CompoundTag();
+        spongeRoot.put("Width", new ShortTag((short) 1));
+        spongeRoot.put("Height", new ShortTag((short) 1));
+        spongeRoot.put("Length", new ShortTag((short) 1));
+        spongeRoot.put("Palette", palette);
+        spongeRoot.put("PaletteMax", new IntTag(1));
+        spongeRoot.put("BlockData", new ByteArrayTag(new byte[]{0}));
+        Path spongeFile = nested.resolve("sample.schem");
+        Tag.writeGZipJavaNBT(spongeFile.toFile(), spongeRoot);
+
+        // Write a classic schematic alongside
+        Path classicFile = inputDir.resolve("basic.schematic");
+        SchematicData data = new SchematicData((short) 1, (short) 1, (short) 1, new int[]{1}, new int[]{0});
+        SchematicConverter.writeClassic(classicFile, data, true);
+
+        Path outputDir = Files.createTempDirectory("schem-output");
+        int count = SchematicConverter.convertDirectory(inputDir, outputDir, true, null, false);
+
+        assertEquals(2, count);
+        assertTrue(Files.exists(outputDir.resolve("basic.schematic")));
+        assertTrue(Files.exists(outputDir.resolve("nested/sample.schematic")));
+    }
+
+    @Test
     void writesSchematicRootName() throws Exception {
         Path output = Files.createTempFile("named", ".schematic");
         SchematicData data = new SchematicData((short) 1, (short) 1, (short) 1, new int[]{1}, new int[]{0});

--- a/cli/src/test/java/com/hivemc/chunker/schematic/SchematicConverterTests.java
+++ b/cli/src/test/java/com/hivemc/chunker/schematic/SchematicConverterTests.java
@@ -1,0 +1,99 @@
+package com.hivemc.chunker.schematic;
+
+import com.hivemc.chunker.mapping.LevelConvertMappings;
+import com.hivemc.chunker.mapping.MappingsFile;
+import com.hivemc.chunker.mapping.parser.SimpleMappingsParser;
+import com.hivemc.chunker.nbt.tags.Tag;
+import com.hivemc.chunker.nbt.tags.collection.CompoundTag;
+import com.hivemc.chunker.nbt.tags.array.ByteArrayTag;
+import com.hivemc.chunker.nbt.tags.primitive.IntTag;
+import com.hivemc.chunker.nbt.tags.primitive.ShortTag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SchematicConverterTests {
+
+    @Test
+    void writesAndReadsExtendedIds() throws Exception {
+        Path tempOut = Files.createTempFile("schematic", ".schematic");
+        SchematicData data = new SchematicData((short) 1, (short) 1, (short) 1, new int[]{5000}, new int[]{32});
+
+        SchematicConverter.writeClassic(tempOut, data, true);
+
+        SchematicData roundTrip = SchematicConverter.read(tempOut);
+        assertEquals(5000, roundTrip.getBlockIds()[0]);
+        assertEquals(32, roundTrip.getBlockData()[0]);
+    }
+
+    @Test
+    void convertsSpongePaletteUsingLevelDat() throws Exception {
+        CompoundTag palette = new CompoundTag();
+        palette.put("custom:block", new IntTag(0));
+
+        CompoundTag spongeRoot = new CompoundTag();
+        spongeRoot.put("Width", new ShortTag((short) 1));
+        spongeRoot.put("Height", new ShortTag((short) 1));
+        spongeRoot.put("Length", new ShortTag((short) 1));
+        spongeRoot.put("Palette", palette);
+        spongeRoot.put("PaletteMax", new IntTag(1));
+        spongeRoot.put("BlockData", new ByteArrayTag(new byte[]{0}));
+
+        Path input = Files.createTempFile("sponge", ".schem");
+        Tag.writeGZipJavaNBT(input.toFile(), spongeRoot);
+
+        CompoundTag level = new CompoundTag();
+        CompoundTag forge = new CompoundTag();
+        CompoundTag itemData = new CompoundTag();
+        itemData.put("custom:block", new IntTag(1300));
+        forge.put("ItemData", itemData);
+        level.put("FML", forge);
+
+        File levelDat = File.createTempFile("level", ".dat");
+        Tag.writeGZipJavaNBT(levelDat, level);
+        LevelConvertMappings.load(levelDat);
+
+        SchematicData loaded = SchematicConverter.read(input);
+        assertEquals(1300, loaded.getBlockIds()[0]);
+
+        Path output = Files.createTempFile("converted", ".schematic");
+        SchematicConverter.convert(input.toFile(), output.toFile(), true);
+        assertTrue(output.toFile().exists());
+    }
+
+    @Test
+    void appliesSimpleMappingsWithLevelDat() throws Exception {
+        // Prepare a legacy schematic with a single custom block id
+        SchematicData data = new SchematicData((short) 1, (short) 1, (short) 1, new int[]{1300}, new int[]{0});
+        Path input = Files.createTempFile("legacy", ".schematic");
+        SchematicConverter.writeClassic(input, data, true);
+
+        // Level.dat that provides both old and new identifiers
+        CompoundTag level = new CompoundTag();
+        CompoundTag forge = new CompoundTag();
+        CompoundTag itemData = new CompoundTag();
+        itemData.put("custom:block", new IntTag(1300));
+        itemData.put("custom:other", new IntTag(2000));
+        forge.put("ItemData", itemData);
+        level.put("FML", forge);
+
+        File levelDat = File.createTempFile("level", ".dat");
+        Tag.writeGZipJavaNBT(levelDat, level);
+        LevelConvertMappings.load(levelDat);
+
+        // Simple mapping to redirect to the new identifier
+        Path mappingFile = Files.createTempFile("simple", ".txt");
+        Files.writeString(mappingFile, "custom:block -> custom:other\n");
+        MappingsFile mappings = SimpleMappingsParser.parse(mappingFile);
+
+        Path output = Files.createTempFile("converted", ".schematic");
+        SchematicConverter.convert(input.toFile(), output.toFile(), true, mappings, true);
+
+        SchematicData converted = SchematicConverter.read(output);
+        assertEquals(2000, converted.getBlockIds()[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow schematic conversion mode to load block/simple mapping files and apply them alongside level.dat lookups
- extend schematic converter to remap identifiers through mappings and level.dat entries when writing classic schematics
- add coverage for simple mapping application during schematic conversion

## Testing
- ./gradlew :cli:test --tests com.hivemc.chunker.schematic.SchematicConverterTests *(fails: Java 17 toolchain not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d03b8ad108323ad371672381b1298)